### PR TITLE
fix(installer): fix off-by-one error in LimitReader size (#2)

### DIFF
--- a/internal/installer/extract.go
+++ b/internal/installer/extract.go
@@ -63,7 +63,7 @@ func ExtractTarGz(archivePath string, destDir string) error {
 				return fmt.Errorf("creating file %s: %w", name, err)
 			}
 
-			if _, err := io.Copy(outFile, io.LimitReader(tr, header.Size+1)); err != nil {
+			if _, err := io.Copy(outFile, io.LimitReader(tr, header.Size)); err != nil {
 				outFile.Close()
 				return fmt.Errorf("writing file %s: %w", name, err)
 			}


### PR DESCRIPTION
## Summary
- Closes #2
- Fix off-by-one error in `io.LimitReader` that allowed files 1 byte over the 100MB limit

## Changes
- `internal/installer/extract.go:L66`: Remove `+1` from `io.LimitReader(tr, header.Size+1)` → `io.LimitReader(tr, header.Size)`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)