### PR TITLE
fix(storage): use consistent skill.json check in IsInstalled (#7)

### DIFF
--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -66,8 +66,8 @@ func IsInstalled(paths *Paths, name string) bool {
 	}
 	// Local check (.claude/skills/)
 	projectRoot := DetectProjectRoot()
-	skillMD := filepath.Join(projectRoot, ".claude", "skills", name, "SKILL.md")
-	_, err := os.Stat(skillMD)
+	localManifest := filepath.Join(projectRoot, ".claude", "skills", name, "skill.json")
+	_, err := os.Stat(localManifest)
 	return err == nil
 }
 


### PR DESCRIPTION
## Summary
- Resolves #7
- `IsInstalled()` checked `SKILL.md` for local installs but `skill.json` for global installs; standardized both to use `skill.json`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)