### PR TITLE
feat(cli): implement --verbose flag for key operations (#8)

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -22,6 +22,7 @@ var installCmd = &cobra.Command{
 		}
 
 		inst := installer.NewInstaller(paths, cfg)
+		inst.Verbose = logVerbose
 		return inst.Install(args[0], forceInstall, globalInstall)
 	},
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/jayl2kor/skillhub/internal/storage"
 	"github.com/jayl2kor/skillhub/pkg/version"
@@ -35,4 +36,10 @@ func init() {
 
 func Execute() error {
 	return rootCmd.Execute()
+}
+
+func logVerbose(format string, args ...any) {
+	if verbose {
+		fmt.Fprintf(os.Stderr, "[verbose] "+format+"\n", args...)
+	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -18,16 +18,19 @@ var runCmd = &cobra.Command{
 		name := args[0]
 		skillArgs := args[1:]
 
+		logVerbose("loading skill %q", name)
 		s, err := storage.GetInstalledSkill(paths, name)
 		if err != nil {
 			return fmt.Errorf("skill %q is not installed", name)
 		}
 
+		logVerbose("skill type: %s, entry: %s", s.Manifest.Type, s.Manifest.Entry)
 		runner, err := runtime.RunnerFor(s.Manifest.Type)
 		if err != nil {
 			return err
 		}
 
+		logVerbose("executing with runner for type %q", s.Manifest.Type)
 		return runner.Run(context.Background(), *s, skillArgs)
 	},
 }

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -30,10 +30,12 @@ var searchCmd = &cobra.Command{
 		}
 
 		client := registry.NewClient()
+		logVerbose("fetching indexes from %d registry(ies)", len(sources))
 		idx, err := client.FetchAllIndexes(sources)
 		if err != nil {
 			return fmt.Errorf("fetching indexes: %w", err)
 		}
+		logVerbose("found %d skill(s) total", len(idx.Skills))
 
 		var results []registry.IndexEntry
 		if len(args) > 0 {

--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -12,21 +12,30 @@ import (
 )
 
 type Installer struct {
-	Paths  *storage.Paths
-	Config *config.Config
-	Client *registry.Client
+	Paths   *storage.Paths
+	Config  *config.Config
+	Client  *registry.Client
+	Verbose func(format string, args ...any)
 }
 
 func NewInstaller(paths *storage.Paths, cfg *config.Config) *Installer {
 	return &Installer{
-		Paths:  paths,
-		Config: cfg,
-		Client: registry.NewClient(),
+		Paths:   paths,
+		Config:  cfg,
+		Client:  registry.NewClient(),
+		Verbose: func(string, ...any) {},
+	}
+}
+
+func (inst *Installer) logVerbose(format string, args ...any) {
+	if inst.Verbose != nil {
+		inst.Verbose(format, args...)
 	}
 }
 
 func (inst *Installer) Install(name string, force bool, global bool) error {
 	// 1. Check if already installed
+	inst.logVerbose("checking if %q is already installed", name)
 	if !force && storage.IsInstalled(inst.Paths, name) {
 		return fmt.Errorf("skill %q is already installed (use --force to reinstall)", name)
 	}
@@ -42,10 +51,12 @@ func (inst *Installer) Install(name string, force bool, global bool) error {
 	}
 
 	// 3. Fetch and merge all indexes
+	inst.logVerbose("fetching indexes from %d registry(ies)", len(sources))
 	idx, err := inst.Client.FetchAllIndexes(sources)
 	if err != nil {
 		return fmt.Errorf("fetching indexes: %w", err)
 	}
+	inst.logVerbose("found %d skill(s) across registries", len(idx.Skills))
 
 	// 4. Find skill
 	entry := idx.Find(name)
@@ -70,6 +81,7 @@ func (inst *Installer) Install(name string, force bool, global bool) error {
 
 	// 6. Download archive
 	cacheFile := filepath.Join(inst.Paths.CacheDir, fmt.Sprintf("%s-%s.tar.gz", name, entry.Version))
+	inst.logVerbose("downloading %s to %s", downloadURL, cacheFile)
 	if err := inst.Client.Download(downloadURL, cacheFile, token, username); err != nil {
 		return fmt.Errorf("downloading skill: %w", err)
 	}
@@ -89,6 +101,7 @@ func (inst *Installer) Install(name string, force bool, global bool) error {
 	}
 	defer os.RemoveAll(tmpDir)
 
+	inst.logVerbose("extracting archive to %s", tmpDir)
 	if err := ExtractTarGz(cacheFile, tmpDir); err != nil {
 		return fmt.Errorf("extracting archive: %w", err)
 	}
@@ -122,6 +135,7 @@ func (inst *Installer) Install(name string, force bool, global bool) error {
 	} else {
 		finalDir = inst.Paths.SkillDir(name)
 	}
+	inst.logVerbose("installing to %s", finalDir)
 	os.MkdirAll(filepath.Dir(finalDir), 0755)
 
 	if force {


### PR DESCRIPTION
## Summary
- Resolves #8
- Implement the previously unused `--verbose` flag with actual logging output

## Changes
- Add `logVerbose` helper in `cli/root.go` that prints to stderr when `--verbose` is set
- Add `Verbose` callback field to `Installer` struct for install step logging
- Add verbose output to: install (6 checkpoints), search (index fetch), run (skill loading/execution)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)