### PR TITLE
feat(runtime): implement shell, python, and node skill runners (#9)

### DIFF
--- a/internal/runtime/exec.go
+++ b/internal/runtime/exec.go
@@ -1,0 +1,49 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/jayl2kor/skillhub/internal/skill"
+)
+
+// ExecRunner runs a skill's entry file using an external interpreter.
+type ExecRunner struct {
+	Command string   // e.g. "bash", "python3", "node"
+	Args    []string // extra args before the script path
+}
+
+func (r *ExecRunner) Run(ctx context.Context, s skill.InstalledSkill, args []string) error {
+	entry := s.Manifest.Entry
+
+	cleaned := filepath.Clean(entry)
+	if filepath.IsAbs(cleaned) || strings.HasPrefix(cleaned, "..") {
+		return fmt.Errorf("invalid entry path: %s", entry)
+	}
+
+	entryPath := filepath.Join(s.Dir, cleaned)
+
+	rel, err := filepath.Rel(s.Dir, entryPath)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return fmt.Errorf("entry path escapes skill directory: %s", entry)
+	}
+
+	if _, err := os.Stat(entryPath); err != nil {
+		return fmt.Errorf("entry file not found: %w", err)
+	}
+
+	cmdArgs := append(r.Args, entryPath)
+	cmdArgs = append(cmdArgs, args...)
+
+	cmd := exec.CommandContext(ctx, r.Command, cmdArgs...)
+	cmd.Dir = s.Dir
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -15,6 +15,12 @@ func RunnerFor(skillType string) (SkillRunner, error) {
 	switch skillType {
 	case "prompt":
 		return &PromptRunner{}, nil
+	case "shell":
+		return &ExecRunner{Command: "bash"}, nil
+	case "python":
+		return &ExecRunner{Command: "python3"}, nil
+	case "node":
+		return &ExecRunner{Command: "node"}, nil
 	default:
 		return nil, fmt.Errorf("unsupported skill type: %s", skillType)
 	}


### PR DESCRIPTION
## Summary
- Resolves #9
- Implement runners for all validated skill types (shell, python, node) that were previously accepted but not runnable

## Changes
- Add `ExecRunner` in `runtime/exec.go` with path validation, directory isolation, and stdio passthrough
- Register shell→bash, python→python3, node→node runners in `RunnerFor()`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)