### PR TITLE
fix: replace string concatenation with filepath.Join for paths (#6)

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/jayl2kor/skillhub/internal/config"
 	"github.com/jayl2kor/skillhub/internal/storage"
@@ -55,7 +56,7 @@ var doctorCmd = &cobra.Command{
 
 		// Check cache writable
 		fmt.Print("Cache writable... ")
-		testFile := paths.CacheDir + "/.doctor-test"
+		testFile := filepath.Join(paths.CacheDir, ".doctor-test")
 		if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
 			fmt.Printf("NO (%v)\n", err)
 			ok = false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 )
@@ -25,9 +26,9 @@ type Config struct {
 func DefaultConfig(home string) *Config {
 	return &Config{
 		Registries: []RegistryEntry{},
-		InstallDir: home + "/skills",
-		CacheDir:   home + "/cache",
-		LogDir:     home + "/logs",
+		InstallDir: filepath.Join(home, "skills"),
+		CacheDir:   filepath.Join(home, "cache"),
+		LogDir:     filepath.Join(home, "logs"),
 	}
 }
 


### PR DESCRIPTION
## Summary
- Resolves #6
- Replace `home + "/skills"` style path construction with `filepath.Join` for cross-platform compatibility

## Changes
- `config/config.go`: Use `filepath.Join` for InstallDir, CacheDir, LogDir in DefaultConfig
- `cli/doctor.go`: Use `filepath.Join` for doctor test file path

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)