### PR TITLE
fix(config): restrict config file permissions to 0600 (#3)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,7 +51,7 @@ func (c *Config) Save(path string) error {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
 
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := os.WriteFile(path, data, 0600); err != nil {
 		return fmt.Errorf("writing config: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Resolves #3
- Config file may contain registry auth tokens; restrict permissions from 0644 to 0600

## Changes
- Change `os.WriteFile(path, data, 0644)` to `os.WriteFile(path, data, 0600)` in `Config.Save()`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)