### PR TITLE
fix(installer): only require SKILL.md when --global flag is set (#5)

### DIFF
--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -108,10 +108,12 @@ func (inst *Installer) Install(name string, force bool, global bool) error {
 		return fmt.Errorf("invalid manifest: %w", err)
 	}
 
-	// 9.5. SKILL.md is required for Claude Code skill
-	skillMDPath := filepath.Join(filepath.Dir(manifestPath), "SKILL.md")
-	if _, err := os.Stat(skillMDPath); os.IsNotExist(err) {
-		return fmt.Errorf("skill archive does not contain SKILL.md (required for Claude Code skill)")
+	// 9.5. SKILL.md is required only for Claude Code integration (--global)
+	if global {
+		skillMDPath := filepath.Join(filepath.Dir(manifestPath), "SKILL.md")
+		if _, err := os.Stat(skillMDPath); os.IsNotExist(err) {
+			return fmt.Errorf("skill archive does not contain SKILL.md (required for Claude Code skill)")
+		}
 	}
 
 	// 10. Determine install target


### PR DESCRIPTION
## Summary
- Resolves #5
- SKILL.md requirement was unconditional, preventing installation of non-Claude-Code skills

## Changes
- Wrap SKILL.md existence check in `if global {}` block so it only applies to Claude Code installs

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)