### PR TITLE
feat: add --tool flag for multi-agent support (#1)

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -9,6 +9,7 @@ import (
 var (
 	forceInstall  bool
 	globalInstall bool
+	installTool   string
 )
 
 var installCmd = &cobra.Command{
@@ -23,12 +24,14 @@ var installCmd = &cobra.Command{
 
 		inst := installer.NewInstaller(paths, cfg)
 		inst.Verbose = logVerbose
+		inst.AgentTool = installTool
 		return inst.Install(args[0], forceInstall, globalInstall)
 	},
 }
 
 func init() {
 	installCmd.Flags().BoolVar(&forceInstall, "force", false, "force reinstall if already installed")
-	installCmd.Flags().BoolVar(&globalInstall, "global", false, "install to project .claude/skills/ for Claude Code")
+	installCmd.Flags().BoolVar(&globalInstall, "global", false, "install to project skills directory for the agent")
+	installCmd.Flags().StringVar(&installTool, "tool", "claude", "agent type for --global install path (claude, cursor, windsurf, cline, generic)")
 	rootCmd.AddCommand(installCmd)
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -5,10 +5,13 @@ import (
 	"fmt"
 
 	"github.com/jayl2kor/skillhub/internal/runtime"
+	"github.com/jayl2kor/skillhub/internal/skill"
 	"github.com/jayl2kor/skillhub/internal/storage"
 
 	"github.com/spf13/cobra"
 )
+
+var toolFlag string
 
 var runCmd = &cobra.Command{
 	Use:   "run <skill>",
@@ -18,10 +21,31 @@ var runCmd = &cobra.Command{
 		name := args[0]
 		skillArgs := args[1:]
 
+		// Validate --tool flag if provided
+		if toolFlag != "" {
+			if _, err := skill.LookupAgent(toolFlag); err != nil {
+				return err
+			}
+		}
+
 		logVerbose("loading skill %q", name)
 		s, err := storage.GetInstalledSkill(paths, name)
 		if err != nil {
 			return fmt.Errorf("skill %q is not installed", name)
+		}
+
+		// Check agent compatibility if manifest specifies compatible_agents
+		if toolFlag != "" && len(s.Manifest.CompatibleAgents) > 0 {
+			compatible := false
+			for _, a := range s.Manifest.CompatibleAgents {
+				if a == toolFlag {
+					compatible = true
+					break
+				}
+			}
+			if !compatible {
+				return fmt.Errorf("skill %q is not compatible with agent %q (compatible: %v)", name, toolFlag, s.Manifest.CompatibleAgents)
+			}
 		}
 
 		logVerbose("skill type: %s, entry: %s", s.Manifest.Type, s.Manifest.Entry)
@@ -36,5 +60,6 @@ var runCmd = &cobra.Command{
 }
 
 func init() {
+	runCmd.Flags().StringVar(&toolFlag, "tool", "", "agent type (claude, cursor, windsurf, cline, generic)")
 	rootCmd.AddCommand(runCmd)
 }

--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -12,10 +12,11 @@ import (
 )
 
 type Installer struct {
-	Paths   *storage.Paths
-	Config  *config.Config
-	Client  *registry.Client
-	Verbose func(format string, args ...any)
+	Paths     *storage.Paths
+	Config    *config.Config
+	Client    *registry.Client
+	Verbose   func(format string, args ...any)
+	AgentTool string // agent type for --global install path (default: "claude")
 }
 
 func NewInstaller(paths *storage.Paths, cfg *config.Config) *Installer {
@@ -132,8 +133,16 @@ func (inst *Installer) Install(name string, force bool, global bool) error {
 	// 10. Determine install target
 	var finalDir string
 	if global {
+		agentTool := inst.AgentTool
+		if agentTool == "" {
+			agentTool = "claude"
+		}
+		agent, err := skill.LookupAgent(agentTool)
+		if err != nil {
+			return err
+		}
 		projectRoot := storage.DetectProjectRoot()
-		finalDir = filepath.Join(projectRoot, ".claude", "skills", name)
+		finalDir = filepath.Join(projectRoot, agent.SkillsPath, name)
 	} else {
 		finalDir = inst.Paths.SkillDir(name)
 	}

--- a/internal/skill/agent.go
+++ b/internal/skill/agent.go
@@ -1,0 +1,35 @@
+package skill
+
+import "fmt"
+
+// AgentType represents a supported AI agent tool.
+type AgentType struct {
+	Name       string // e.g. "claude", "cursor"
+	SkillsPath string // relative path from project root, e.g. ".claude/skills"
+}
+
+var knownAgents = map[string]AgentType{
+	"claude":  {Name: "claude", SkillsPath: ".claude/skills"},
+	"cursor":  {Name: "cursor", SkillsPath: ".cursor/skills"},
+	"windsurf": {Name: "windsurf", SkillsPath: ".windsurf/skills"},
+	"cline":   {Name: "cline", SkillsPath: ".cline/skills"},
+	"generic": {Name: "generic", SkillsPath: ".ai/skills"},
+}
+
+// LookupAgent returns the agent type definition for the given name.
+func LookupAgent(name string) (AgentType, error) {
+	a, ok := knownAgents[name]
+	if !ok {
+		return AgentType{}, fmt.Errorf("unknown agent type %q (supported: claude, cursor, windsurf, cline, generic)", name)
+	}
+	return a, nil
+}
+
+// AllAgentNames returns all supported agent type names.
+func AllAgentNames() []string {
+	names := make([]string, 0, len(knownAgents))
+	for name := range knownAgents {
+		names = append(names, name)
+	}
+	return names
+}

--- a/internal/skill/manifest.go
+++ b/internal/skill/manifest.go
@@ -21,15 +21,16 @@ var (
 )
 
 type Manifest struct {
-	Name        string   `json:"name"`
-	Version     string   `json:"version"`
-	Description string   `json:"description"`
-	Entry       string   `json:"entry"`
-	Type        string   `json:"type"`
-	Tags        []string `json:"tags,omitempty"`
-	Author      string   `json:"author,omitempty"`
-	Homepage    string   `json:"homepage,omitempty"`
-	License     string   `json:"license,omitempty"`
+	Name             string   `json:"name"`
+	Version          string   `json:"version"`
+	Description      string   `json:"description"`
+	Entry            string   `json:"entry"`
+	Type             string   `json:"type"`
+	Tags             []string `json:"tags,omitempty"`
+	Author           string   `json:"author,omitempty"`
+	Homepage         string   `json:"homepage,omitempty"`
+	License          string   `json:"license,omitempty"`
+	CompatibleAgents []string `json:"compatible_agents,omitempty"`
 }
 
 func LoadManifest(path string) (*Manifest, error) {


### PR DESCRIPTION
## Summary
- Resolves #1
- Enable skillhub to work with multiple AI agents (Claude, Cursor, Windsurf, Cline, generic) via `--tool` flag

## Changes
- Add `compatible_agents` optional field to `skill.json` manifest
- Add agent type registry (`skill/agent.go`) with per-agent skill paths
- Add `--tool` flag to `run` command with agent compatibility check
- Add `--tool` flag to `install` command for agent-specific `--global` install paths
- Default agent is `claude` for backward compatibility

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)