### PR TITLE
fix(skill): change generic agent path from .ai/skills to .agent/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ When `--global` is used, the skill is installed to the project-level agent direc
 | `cursor` | `.cursor/skills/<name>` |
 | `windsurf` | `.windsurf/skills/<name>` |
 | `cline` | `.cline/skills/<name>` |
-| `generic` | `.ai/skills/<name>` |
+| `generic` | `.agent/skills/<name>` |
 
 ### Run Flags
 

--- a/internal/skill/agent.go
+++ b/internal/skill/agent.go
@@ -13,7 +13,7 @@ var knownAgents = map[string]AgentType{
 	"cursor":   {Name: "cursor", SkillsPath: ".cursor/skills"},
 	"windsurf": {Name: "windsurf", SkillsPath: ".windsurf/skills"},
 	"cline":    {Name: "cline", SkillsPath: ".cline/skills"},
-	"generic":  {Name: "generic", SkillsPath: ".ai/skills"},
+	"generic":  {Name: "generic", SkillsPath: ".agent/skills"},
 }
 
 // LookupAgent returns the agent type definition for the given name.


### PR DESCRIPTION
## Summary
- Resolves #42
- Change generic agent skills path from `.ai/skills` to `.agent/skills`

## Changes
- `internal/skill/agent.go`: update `SkillsPath` for generic agent
- `README.md`: update agent install path table

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

Closes #42