### PR TITLE
feat: add show command with subcommands (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ skillhub install code-review --global --tool claude
 | `install <skill>` | Install a skill from a registry |
 | `list` | List installed skills |
 | `info <skill>` | Show detailed skill information |
+| `show manifest <skill>` | Show raw skill.json |
+| `show readme <skill>` | Show SKILL.md |
+| `show entry <skill>` | Show entry file content |
+| `show all <skill>` | Show manifest + readme |
 | `run <skill> [args...]` | Run an installed skill |
 | `update [skill]` | Update installed skills to latest versions |
 | `remove <skill>` | Remove an installed skill |

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -1,0 +1,245 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/jayl2kor/skillhub/internal/installer"
+	"github.com/jayl2kor/skillhub/internal/registry"
+	"github.com/jayl2kor/skillhub/internal/skill"
+	"github.com/jayl2kor/skillhub/internal/storage"
+
+	"github.com/spf13/cobra"
+)
+
+var showCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show skill contents before installing",
+	Long:  "Inspect skill files (manifest, readme, entry) for installed or remote skills.",
+}
+
+var showManifestCmd = &cobra.Command{
+	Use:   "manifest <skill>",
+	Short: "Show raw skill.json",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir, cleanup, err := resolveSkillDir(args[0])
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
+		data, err := os.ReadFile(filepath.Join(dir, "skill.json"))
+		if err != nil {
+			return fmt.Errorf("reading skill.json: %w", err)
+		}
+		fmt.Print(string(data))
+		return nil
+	},
+}
+
+var showReadmeCmd = &cobra.Command{
+	Use:   "readme <skill>",
+	Short: "Show SKILL.md",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir, cleanup, err := resolveSkillDir(args[0])
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
+		data, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
+		if err != nil {
+			return fmt.Errorf("reading SKILL.md: %w", err)
+		}
+		fmt.Print(string(data))
+		return nil
+	},
+}
+
+var showEntryCmd = &cobra.Command{
+	Use:   "entry <skill>",
+	Short: "Show entry file content",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir, cleanup, err := resolveSkillDir(args[0])
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
+		m, err := skill.LoadManifest(filepath.Join(dir, "skill.json"))
+		if err != nil {
+			return fmt.Errorf("loading manifest: %w", err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, m.Entry))
+		if err != nil {
+			return fmt.Errorf("reading entry file %q: %w", m.Entry, err)
+		}
+		fmt.Print(string(data))
+		return nil
+	},
+}
+
+var showAllCmd = &cobra.Command{
+	Use:   "all <skill>",
+	Short: "Show manifest and readme",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir, cleanup, err := resolveSkillDir(args[0])
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
+		manifest, err := os.ReadFile(filepath.Join(dir, "skill.json"))
+		if err != nil {
+			return fmt.Errorf("reading skill.json: %w", err)
+		}
+
+		// Pretty-print manifest JSON
+		var raw json.RawMessage
+		if err := json.Unmarshal(manifest, &raw); err == nil {
+			if pretty, err := json.MarshalIndent(raw, "", "  "); err == nil {
+				manifest = pretty
+			}
+		}
+
+		fmt.Println(string(manifest))
+		fmt.Println("---")
+
+		readme, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
+		if err != nil {
+			fmt.Println("(no SKILL.md)")
+			return nil
+		}
+		fmt.Print(string(readme))
+		return nil
+	},
+}
+
+func init() {
+	showCmd.AddCommand(showManifestCmd)
+	showCmd.AddCommand(showReadmeCmd)
+	showCmd.AddCommand(showEntryCmd)
+	showCmd.AddCommand(showAllCmd)
+	rootCmd.AddCommand(showCmd)
+}
+
+// resolveSkillDir returns the directory containing the skill files.
+// For installed skills, it returns the installed directory.
+// For remote skills, it downloads and extracts to a temp directory.
+// The caller must call cleanup() when done.
+func resolveSkillDir(name string) (dir string, cleanup func(), err error) {
+	noop := func() {}
+
+	// 1. Check if installed locally
+	if storage.IsInstalled(paths, name) {
+		s, err := storage.GetInstalledSkill(paths, name)
+		if err == nil {
+			return s.Dir, noop, nil
+		}
+	}
+
+	// 2. Fetch from registry
+	cfg, err := loadOrSetupConfig()
+	if err != nil {
+		return "", noop, err
+	}
+
+	if len(cfg.Registries) == 0 {
+		return "", noop, fmt.Errorf("skill %q not found locally and no registries configured", name)
+	}
+
+	sources := make([]registry.RepoSource, len(cfg.Registries))
+	for i, r := range cfg.Registries {
+		sources[i] = registry.RepoSource{Name: r.Name, URL: r.URL, Token: r.Token, Username: r.Username, Branch: r.Branch}
+	}
+
+	client := registry.NewClient()
+	idx, err := client.FetchAllIndexes(sources)
+	if err != nil {
+		return "", noop, fmt.Errorf("fetching indexes: %w", err)
+	}
+
+	entry := idx.Find(name)
+	if entry == nil {
+		return "", noop, fmt.Errorf("skill %q not found", name)
+	}
+
+	// Resolve download URL and credentials
+	var downloadURL string
+	var token, username string
+	for _, src := range sources {
+		if src.Name == entry.Registry {
+			downloadURL = src.ResolveDownloadURL(entry.DownloadURL)
+			token = src.Token
+			username = src.Username
+			break
+		}
+	}
+	if downloadURL == "" {
+		downloadURL = entry.DownloadURL
+	}
+
+	// Download archive to temp
+	tmpDir, err := os.MkdirTemp("", "skillhub-show-*")
+	if err != nil {
+		return "", noop, fmt.Errorf("creating temp directory: %w", err)
+	}
+	cleanupFn := func() { os.RemoveAll(tmpDir) }
+
+	archivePath := filepath.Join(tmpDir, "archive.tar.gz")
+	logVerbose("downloading %s", downloadURL)
+	if err := client.Download(downloadURL, archivePath, token, username); err != nil {
+		cleanupFn()
+		return "", noop, fmt.Errorf("downloading skill: %w", err)
+	}
+
+	// Extract
+	extractDir := filepath.Join(tmpDir, "extracted")
+	if err := os.MkdirAll(extractDir, 0755); err != nil {
+		cleanupFn()
+		return "", noop, fmt.Errorf("creating extract directory: %w", err)
+	}
+
+	if err := installer.ExtractTarGz(archivePath, extractDir); err != nil {
+		cleanupFn()
+		return "", noop, fmt.Errorf("extracting archive: %w", err)
+	}
+
+	// Find manifest (same logic as installer.findManifest)
+	skillDir := findSkillDir(extractDir)
+	if skillDir == "" {
+		cleanupFn()
+		return "", noop, fmt.Errorf("skill archive does not contain skill.json")
+	}
+
+	return skillDir, cleanupFn, nil
+}
+
+// findSkillDir locates the directory containing skill.json within the extracted archive.
+func findSkillDir(dir string) string {
+	if _, err := os.Stat(filepath.Join(dir, "skill.json")); err == nil {
+		return dir
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			sub := filepath.Join(dir, entry.Name())
+			if _, err := os.Stat(filepath.Join(sub, "skill.json")); err == nil {
+				return sub
+			}
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
## Summary
- Add `skillhub show` command with `manifest`, `readme`, `entry`, `all` subcommands
- Supports both installed and remote skills (downloads from registry on demand)
- `resolveSkillDir` helper resolves skill directory with automatic cleanup for remote skills

## Test plan
- [x] `skillhub show manifest <installed-skill>` outputs raw skill.json
- [x] `skillhub show readme <installed-skill>` outputs SKILL.md
- [x] `skillhub show entry <installed-skill>` outputs entry file
- [x] `skillhub show all <installed-skill>` outputs manifest + `---` + readme
- [ ] Remote skill: downloads, extracts, shows content, cleans up temp dir
- [ ] `go build ./...`, `go vet ./...`, `go test ./...` all pass

Closes #23
