### PR TITLE
feat: add completion command for shell autocompletion (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ skillhub install code-review --global --tool claude
 | `repo add <url>` | Add a skill registry |
 | `repo list` | List configured registries |
 | `repo remove <name>` | Remove a registry |
+| `completion <shell>` | Generate shell autocompletion (bash/zsh/fish/powershell) |
 
 ### Global Flags
 

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -18,7 +18,7 @@ func TestSubcommandRegistration(t *testing.T) {
 	expected := []string{
 		"init", "list", "doctor", "repo", "search",
 		"info", "install", "run", "update", "remove",
-		"cache", "create", "lint", "package",
+		"cache", "create", "lint", "package", "completion",
 	}
 
 	commands := make(map[string]bool)

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:       "completion <shell>",
+	Short:     "Generate shell autocompletion script",
+	Long:      "Generate autocompletion scripts for bash, zsh, fish, or powershell.",
+	Args:      cobra.ExactArgs(1),
+	ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return rootCmd.GenBashCompletion(os.Stdout)
+		case "zsh":
+			return rootCmd.GenZshCompletion(os.Stdout)
+		case "fish":
+			return rootCmd.GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			return rootCmd.GenPowerShellCompletion(os.Stdout)
+		default:
+			return fmt.Errorf("unsupported shell %q (supported: bash, zsh, fish, powershell)", args[0])
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}


### PR DESCRIPTION
## Summary
- Add `skillhub completion <shell>` using Cobra's built-in completion generators
- Supports bash, zsh, fish, powershell

## Test plan
- [x] `skillhub completion bash` outputs valid bash completion script
- [x] `skillhub completion zsh` outputs valid zsh completion script
- [x] `go build/vet/test` all pass

Closes #29
