### PR TITLE
feat: add repo update command to cache registry indexes (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ skillhub install code-review --global --tool claude
 | `repo remove <name>` | Remove a registry |
 | `completion <shell>` | Generate shell autocompletion (bash/zsh/fish/powershell) |
 | `repo index <dir>` | Generate index.json from skill archives |
+| `repo update [name]` | Fetch and cache registry indexes |
 
 ### Global Flags
 

--- a/internal/cli/repo_update.go
+++ b/internal/cli/repo_update.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/jayl2kor/skillhub/internal/registry"
+
+	"github.com/spf13/cobra"
+)
+
+var repoUpdateCmd = &cobra.Command{
+	Use:   "update [name]",
+	Short: "Fetch and cache registry indexes locally",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := loadOrSetupConfig()
+		if err != nil {
+			return err
+		}
+
+		if len(cfg.Registries) == 0 {
+			return fmt.Errorf("no registries configured; use 'skillhub repo add' to add one")
+		}
+
+		indexDir := filepath.Join(paths.CacheDir, "indexes")
+		if err := os.MkdirAll(indexDir, 0755); err != nil {
+			return fmt.Errorf("creating index cache directory: %w", err)
+		}
+
+		client := registry.NewClient()
+		var updated int
+
+		for _, r := range cfg.Registries {
+			if len(args) > 0 && r.Name != args[0] {
+				continue
+			}
+
+			src := &registry.RepoSource{
+				Name: r.Name, URL: r.URL, Token: r.Token,
+				Username: r.Username, Branch: r.Branch,
+			}
+
+			logVerbose("fetching index from %s", r.Name)
+			idx, err := client.FetchIndex(src)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: failed to update %q: %v\n", r.Name, err)
+				continue
+			}
+
+			data, err := json.MarshalIndent(idx, "", "  ")
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: failed to marshal index for %q: %v\n", r.Name, err)
+				continue
+			}
+
+			cachePath := filepath.Join(indexDir, r.Name+".json")
+			if err := os.WriteFile(cachePath, data, 0644); err != nil {
+				return fmt.Errorf("writing cached index for %q: %w", r.Name, err)
+			}
+
+			fmt.Printf("Updated %q (%d skills)\n", r.Name, len(idx.Skills))
+			updated++
+		}
+
+		if len(args) > 0 && updated == 0 {
+			return fmt.Errorf("registry %q not found", args[0])
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	repoCmd.AddCommand(repoUpdateCmd)
+}


### PR DESCRIPTION
## Summary
- Add `skillhub repo update [name]` to fetch and cache registry indexes locally
- Caches to `~/.skillhub/cache/indexes/{name}.json`
- Supports updating all registries or a specific one by name

## Test plan
- [x] `skillhub repo update` fetches and caches all registry indexes
- [x] `skillhub repo update my-registry` updates only the specified registry
- [x] Gracefully warns on unreachable registries
- [x] `go build/vet/test` all pass

Closes #30
