### PR TITLE
feat: add --output flag for JSON/YAML/table output formats (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ skillhub install code-review --global --tool claude
 | `--home <path>` | `~/.skillhub` | Workspace directory (or `SKILLHUB_HOME` env) |
 | `--verbose` | `false` | Enable verbose output |
 | `--version` | - | Print version info |
+| `-o, --output` | `table` | Output format for list/search/info (table, json, yaml) |
 
 ### Install Flags
 

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -22,6 +22,9 @@ var infoCmd = &cobra.Command{
 		if installed {
 			s, err := storage.GetInstalledSkill(paths, name)
 			if err == nil {
+				if isStructuredOutput() {
+					return printFormatted(s)
+				}
 				fmt.Printf("Name:        %s\n", s.Manifest.Name)
 				fmt.Printf("Version:     %s\n", s.Manifest.Version)
 				fmt.Printf("Description: %s\n", s.Manifest.Description)
@@ -73,6 +76,10 @@ var infoCmd = &cobra.Command{
 			return fmt.Errorf("skill %q not found", name)
 		}
 
+		if isStructuredOutput() {
+			return printFormatted(entry)
+		}
+
 		fmt.Printf("Name:        %s\n", entry.Name)
 		fmt.Printf("Version:     %s\n", entry.Version)
 		fmt.Printf("Description: %s\n", entry.Description)
@@ -87,5 +94,6 @@ var infoCmd = &cobra.Command{
 }
 
 func init() {
+	infoCmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "output format (table, json, yaml)")
 	rootCmd.AddCommand(infoCmd)
 }

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -19,6 +19,20 @@ var listCmd = &cobra.Command{
 			return fmt.Errorf("listing skills: %w", err)
 		}
 
+		if isStructuredOutput() {
+			type entry struct {
+				Name    string `json:"name" yaml:"name"`
+				Version string `json:"version" yaml:"version"`
+				Type    string `json:"type" yaml:"type"`
+				Dir     string `json:"dir" yaml:"dir"`
+			}
+			out := make([]entry, len(skills))
+			for i, s := range skills {
+				out[i] = entry{s.Manifest.Name, s.Manifest.Version, s.Manifest.Type, s.Dir}
+			}
+			return printFormatted(out)
+		}
+
 		if len(skills) == 0 {
 			fmt.Println("No skills installed.")
 			return nil
@@ -36,5 +50,6 @@ var listCmd = &cobra.Command{
 }
 
 func init() {
+	listCmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "output format (table, json, yaml)")
 	rootCmd.AddCommand(listCmd)
 }

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+var outputFormat string
+
+func printFormatted(data any) error {
+	switch outputFormat {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(data)
+	case "yaml":
+		return yaml.NewEncoder(os.Stdout).Encode(data)
+	default:
+		return fmt.Errorf("unsupported output format %q", outputFormat)
+	}
+}
+
+func isStructuredOutput() bool {
+	return outputFormat == "json" || outputFormat == "yaml"
+}

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -43,6 +43,11 @@ var searchCmd = &cobra.Command{
 		} else {
 			results = idx.Skills
 		}
+
+		if isStructuredOutput() {
+			return printFormatted(results)
+		}
+
 		if len(results) == 0 {
 			fmt.Println("No skills found.")
 			return nil
@@ -65,5 +70,6 @@ var searchCmd = &cobra.Command{
 }
 
 func init() {
+	searchCmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "output format (table, json, yaml)")
 	rootCmd.AddCommand(searchCmd)
 }


### PR DESCRIPTION
## Summary
- Add `-o/--output` flag to `list`, `search`, and `info` commands
- Supports `table` (default), `json`, and `yaml` output formats
- Shared `output.go` helper for consistent formatting across commands

## Test plan
- [x] `skillhub list -o json` outputs JSON array
- [x] `skillhub search query -o yaml` outputs YAML
- [x] `skillhub info skill -o json` outputs JSON object
- [x] Default table output unchanged
- [x] `go build/vet/test` all pass

Closes #32
