### PR TITLE
fix: replace Korean setup prompts with English (#51)

### DIFF
--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -22,7 +22,7 @@ func loadOrSetupConfig() (*config.Config, error) {
 
 	reader := bufio.NewReader(os.Stdin)
 
-	fmt.Print("skillhub 워크스페이스가 초기화되지 않았습니다. 지금 설정하시겠습니까? [Y/n]: ")
+	fmt.Print("Workspace not initialized. Set up now? [Y/n]: ")
 	answer, _ := reader.ReadString('\n')
 	answer = strings.TrimSpace(answer)
 	if answer != "" && strings.ToLower(answer) != "y" {
@@ -32,26 +32,26 @@ func loadOrSetupConfig() (*config.Config, error) {
 	if err := paths.EnsureDirectories(); err != nil {
 		return nil, fmt.Errorf("creating directories: %w", err)
 	}
-	fmt.Printf("워크스페이스를 생성했습니다: %s\n", paths.Home)
+	fmt.Printf("Created workspace: %s\n", paths.Home)
 
 	cfg = config.DefaultConfig(paths.Home)
 
-	fmt.Print("레지스트리 URL을 입력하세요 (건너뛰려면 Enter): ")
+	fmt.Print("Enter registry URL (press Enter to skip): ")
 	repoURL, _ := reader.ReadString('\n')
 	repoURL = strings.TrimSpace(repoURL)
 
 	if repoURL != "" {
 		source, err := registry.ParseRepoURL(repoURL)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "경고: URL 파싱 실패 (%v), 레지스트리 추가를 건너뜁니다.\n", err)
+			fmt.Fprintf(os.Stderr, "Warning: failed to parse URL (%v), skipping registry.\n", err)
 		} else {
-			fmt.Print("토큰을 입력하세요 (불필요하면 Enter): ")
+			fmt.Print("Enter token (press Enter to skip): ")
 			token, _ := reader.ReadString('\n')
 			token = strings.TrimSpace(token)
 			source.Token = token
 
 			if token != "" {
-				fmt.Print("사용자 이름을 입력하세요 (GitHub Enterprise용, 불필요하면 Enter): ")
+				fmt.Print("Enter username (for GitHub Enterprise, press Enter to skip): ")
 				username, _ := reader.ReadString('\n')
 				username = strings.TrimSpace(username)
 				source.Username = username
@@ -60,22 +60,22 @@ func loadOrSetupConfig() (*config.Config, error) {
 			client := registry.NewClient()
 			source.Branch = client.DetectDefaultBranch(source)
 			if _, err := client.FetchIndex(source); err != nil {
-				fmt.Fprintf(os.Stderr, "경고: 레지스트리 인덱스에 접근할 수 없습니다 (%v)\n", err)
-				fmt.Print("그래도 레지스트리를 추가하시겠습니까? [y/N]: ")
+				fmt.Fprintf(os.Stderr, "Warning: cannot access registry index (%v)\n", err)
+				fmt.Print("Add the registry anyway? [y/N]: ")
 				forceAnswer, _ := reader.ReadString('\n')
 				forceAnswer = strings.TrimSpace(forceAnswer)
 				if strings.ToLower(forceAnswer) == "y" {
 					if err := cfg.AddRegistry(source.Name, source.URL, source.Token, source.Username, source.Branch); err != nil {
-						fmt.Fprintf(os.Stderr, "경고: 레지스트리 추가 실패 (%v)\n", err)
+						fmt.Fprintf(os.Stderr, "Warning: failed to add registry (%v)\n", err)
 					} else {
-						fmt.Printf("레지스트리 '%s'를 추가했습니다.\n", source.Name)
+						fmt.Printf("Added registry '%s'.\n", source.Name)
 					}
 				}
 			} else {
 				if err := cfg.AddRegistry(source.Name, source.URL, source.Token, source.Username, source.Branch); err != nil {
-					fmt.Fprintf(os.Stderr, "경고: 레지스트리 추가 실패 (%v)\n", err)
+					fmt.Fprintf(os.Stderr, "Warning: failed to add registry (%v)\n", err)
 				} else {
-					fmt.Printf("레지스트리 '%s'를 추가했습니다.\n", source.Name)
+					fmt.Printf("Added registry '%s'.\n", source.Name)
 				}
 			}
 		}
@@ -85,6 +85,6 @@ func loadOrSetupConfig() (*config.Config, error) {
 		return nil, fmt.Errorf("saving config: %w", err)
 	}
 
-	fmt.Println("설정이 완료되었습니다!")
+	fmt.Println("Setup complete!")
 	return cfg, nil
 }


### PR DESCRIPTION
## Summary
- Replace all hardcoded Korean prompts in setup.go with English
- Consistent with the rest of the CLI which is already in English

Closes #51