### PR TITLE
feat: add --version flag to install and --versions to search (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ skillhub install code-review --global --tool claude
 | `--force` | `false` | Force reinstall |
 | `--global` | `false` | Install to project agent directory |
 | `--tool <type>` | `claude` | Agent type for `--global` install |
+| `--version <ver>` | - | Install a specific version |
 
 When `--global` is used, the skill is installed to the project-level agent directory and requires a `SKILL.md` file in the package.
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -7,9 +7,10 @@ import (
 )
 
 var (
-	forceInstall  bool
-	globalInstall bool
-	installTool   string
+	forceInstall   bool
+	globalInstall  bool
+	installTool    string
+	installVersion string
 )
 
 var installCmd = &cobra.Command{
@@ -25,6 +26,7 @@ var installCmd = &cobra.Command{
 		inst := installer.NewInstaller(paths, cfg)
 		inst.Verbose = logVerbose
 		inst.AgentTool = installTool
+		inst.Version = installVersion
 		return inst.Install(args[0], forceInstall, globalInstall)
 	},
 }
@@ -33,5 +35,6 @@ func init() {
 	installCmd.Flags().BoolVar(&forceInstall, "force", false, "force reinstall if already installed")
 	installCmd.Flags().BoolVar(&globalInstall, "global", false, "install to project skills directory for the agent")
 	installCmd.Flags().StringVar(&installTool, "tool", "claude", "agent type for --global install path (claude, cursor, windsurf, cline, generic)")
+	installCmd.Flags().StringVar(&installVersion, "version", "", "install a specific version")
 	rootCmd.AddCommand(installCmd)
 }

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var searchVersions bool
+
 var searchCmd = &cobra.Command{
 	Use:   "search [query]",
 	Short: "Search for skills in registries (omit query to list all)",
@@ -43,6 +45,18 @@ var searchCmd = &cobra.Command{
 		} else {
 			results = idx.Skills
 		}
+		// Deduplicate by name unless --versions is set
+		if !searchVersions {
+			seen := make(map[string]bool)
+			var deduped []registry.IndexEntry
+			for _, r := range results {
+				if !seen[r.Name] {
+					seen[r.Name] = true
+					deduped = append(deduped, r)
+				}
+			}
+			results = deduped
+		}
 
 		if isStructuredOutput() {
 			return printFormatted(results)
@@ -71,5 +85,6 @@ var searchCmd = &cobra.Command{
 
 func init() {
 	searchCmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "output format (table, json, yaml)")
+	searchCmd.Flags().BoolVar(&searchVersions, "versions", false, "show all available versions")
 	rootCmd.AddCommand(searchCmd)
 }

--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -17,6 +17,7 @@ type Installer struct {
 	Client    *registry.Client
 	Verbose   func(format string, args ...any)
 	AgentTool string // agent type for --global install path (default: "claude")
+	Version   string // specific version to install (empty = latest)
 }
 
 func NewInstaller(paths *storage.Paths, cfg *config.Config) *Installer {
@@ -60,9 +61,17 @@ func (inst *Installer) Install(name string, force bool, global bool) error {
 	inst.logVerbose("found %d skill(s) across registries", len(idx.Skills))
 
 	// 4. Find skill
-	entry := idx.Find(name)
-	if entry == nil {
-		return fmt.Errorf("skill %q not found in any registry", name)
+	var entry *registry.IndexEntry
+	if inst.Version != "" {
+		entry = idx.FindVersion(name, inst.Version)
+		if entry == nil {
+			return fmt.Errorf("skill %q version %q not found in any registry", name, inst.Version)
+		}
+	} else {
+		entry = idx.Find(name)
+		if entry == nil {
+			return fmt.Errorf("skill %q not found in any registry", name)
+		}
 	}
 
 	// 5. Resolve download URL and credentials

--- a/internal/registry/index.go
+++ b/internal/registry/index.go
@@ -69,6 +69,16 @@ func (idx *Index) Find(name string) *IndexEntry {
 	return nil
 }
 
+// FindVersion returns an entry matching both name and version.
+func (idx *Index) FindVersion(name, version string) *IndexEntry {
+	for _, entry := range idx.Skills {
+		if entry.Name == name && entry.Version == version {
+			return &entry
+		}
+	}
+	return nil
+}
+
 func MergeIndexes(indexes ...*Index) *Index {
 	merged := &Index{}
 	for _, idx := range indexes {


### PR DESCRIPTION
## Summary
- Add `--version` flag to `install` for installing specific versions
- Add `--versions` flag to `search` to show all available versions
- Add `FindVersion(name, version)` to registry index
- Search now deduplicates by name by default, `--versions` shows all

## Test plan
- [x] `skillhub install my-skill --version 1.0.0` installs specific version
- [x] `skillhub search --versions` shows all version entries
- [x] `skillhub search` (default) deduplicates by name
- [x] `go build/vet/test` all pass

Closes #27
