### PR TITLE
fix(cli): validate SKILL.md presence in package command

### DIFF
--- a/internal/cli/package.go
+++ b/internal/cli/package.go
@@ -45,6 +45,12 @@ var packageCmd = &cobra.Command{
 			return fmt.Errorf("entry file %q not found", m.Entry)
 		}
 
+		// Verify SKILL.md exists
+		skillMDPath := filepath.Join(dir, "SKILL.md")
+		if _, err := os.Stat(skillMDPath); os.IsNotExist(err) {
+			return fmt.Errorf("SKILL.md not found (required)")
+		}
+
 		// Build archive
 		filename := fmt.Sprintf("%s-%s.tar.gz", m.Name, m.Version)
 		destPath := filepath.Join(packageDest, filename)


### PR DESCRIPTION
Closes #76

## Summary
- `package` command now checks for SKILL.md before building archive, consistent with `install` and `lint`

## Changes
- `internal/cli/package.go` — add SKILL.md existence check after entry file validation

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)