### PR TITLE
fix(cli): warn when --untar/--verify used with directory-based skills

### DIFF
--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -72,6 +72,12 @@ var pullCmd = &cobra.Command{
 			if matchedSource == nil {
 				return fmt.Errorf("registry source not found for skill %q", name)
 			}
+			if pullUntar {
+				fmt.Fprintln(os.Stderr, "warning: --untar has no effect for directory-based skills")
+			}
+			if pullVerify {
+				fmt.Fprintln(os.Stderr, "warning: --verify is not supported for directory-based skills (no checksum)")
+			}
 
 			destPath := filepath.Join(pullDest, name)
 			if err := os.MkdirAll(destPath, 0755); err != nil {


### PR DESCRIPTION
Closes #81

## Summary
- Warn users when `--untar` or `--verify` flags are used with directory-based skills (these flags only apply to archive mode)

## Changes
- `internal/cli/pull.go` — add warning messages in directory mode branch

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)