### PR TITLE
feat(registry): detect GitHub API rate limit with user-friendly message

### DIFF
--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -259,6 +259,15 @@ func (c *Client) newRequest(rawURL, token, username string) (*http.Request, erro
 
 func checkResponse(resp *http.Response, rawURL, token string) error {
 	credentialHint := "--token and --username"
+
+	// Check for GitHub API rate limiting
+	if resp.StatusCode == http.StatusForbidden && resp.Header.Get("X-RateLimit-Remaining") == "0" {
+		if token == "" {
+			return fmt.Errorf("GitHub API rate limit exceeded (60/hr for unauthenticated requests). Use 'skillhub repo add <url> --token <PAT>' to increase to 5000/hr")
+		}
+		return fmt.Errorf("GitHub API rate limit exceeded. Wait or use a different token")
+	}
+
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		if token == "" {
 			return fmt.Errorf("HTTP %d from %s (authentication required; use %s to provide credentials)", resp.StatusCode, rawURL, credentialHint)

--- a/internal/registry/client_test.go
+++ b/internal/registry/client_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -181,6 +182,46 @@ func TestDownloadLocal(t *testing.T) {
 	}
 	if string(data) != "local archive" {
 		t.Errorf("expected 'local archive', got %q", string(data))
+	}
+}
+
+func TestCheckResponseRateLimit(t *testing.T) {
+	// Rate limited with no token
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header:     http.Header{"X-Ratelimit-Remaining": []string{"0"}},
+	}
+	err := checkResponse(resp, "https://api.github.com/repos/o/r/contents/x", "")
+	if err == nil {
+		t.Fatal("expected error for rate limit")
+	}
+	if !strings.Contains(err.Error(), "rate limit exceeded") {
+		t.Errorf("expected rate limit message, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "60/hr") {
+		t.Errorf("expected unauthenticated hint, got: %v", err)
+	}
+
+	// Rate limited with token
+	err = checkResponse(resp, "https://api.github.com/repos/o/r/contents/x", "tok")
+	if err == nil {
+		t.Fatal("expected error for rate limit with token")
+	}
+	if !strings.Contains(err.Error(), "rate limit exceeded") {
+		t.Errorf("expected rate limit message, got: %v", err)
+	}
+
+	// Forbidden but NOT rate limited (no X-RateLimit-Remaining header)
+	resp2 := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header:     http.Header{},
+	}
+	err = checkResponse(resp2, "https://example.com", "")
+	if err == nil {
+		t.Fatal("expected error for forbidden")
+	}
+	if strings.Contains(err.Error(), "rate limit") {
+		t.Errorf("should not mention rate limit: %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #78

## Summary
- Detect GitHub API rate limiting via `X-RateLimit-Remaining: 0` header on 403 responses
- Show actionable message: suggest adding a PAT for unauthenticated users

## Changes
- `internal/registry/client.go` — rate limit check in `checkResponse()` before generic 403 handling
- `internal/registry/client_test.go` — add `TestCheckResponseRateLimit`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)