### PR TITLE
feat(registry): add progress callback for directory downloads

### DIFF
--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -105,6 +105,9 @@ func (inst *Installer) Install(name string, force bool, global bool) error {
 			return fmt.Errorf("registry source not found for skill %q", name)
 		}
 		inst.logVerbose("downloading directory %s", entry.DownloadURL)
+		inst.Client.OnProgress = func(filename string) {
+			inst.logVerbose("  %s", filename)
+		}
 		if err := inst.Client.DownloadDirectory(matchedSource, entry.DownloadURL, tmpDir); err != nil {
 			return fmt.Errorf("downloading skill directory: %w", err)
 		}

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -20,6 +20,7 @@ const (
 
 type Client struct {
 	HTTPClient *http.Client
+	OnProgress func(filename string) // called for each file downloaded in directory mode
 }
 
 func NewClient() *Client {
@@ -166,18 +167,19 @@ type githubContentEntry struct {
 
 // DownloadDirectory downloads all files from a directory source into destDir.
 // For local paths, it copies the directory tree. For GitHub, it uses the Contents API.
+// If OnProgress is set, it is called with each file's relative name after download.
 func (c *Client) DownloadDirectory(source *RepoSource, dirPath, destDir string) error {
 	dirPath = strings.TrimSuffix(dirPath, "/")
 
 	if isLocalPath(source.URL) {
 		srcDir := filepath.Join(source.URL, dirPath)
-		return copyDirectory(srcDir, destDir)
+		return c.copyDirectory(srcDir, destDir)
 	}
 
 	return c.downloadGitHubDirectory(source, dirPath, destDir)
 }
 
-func copyDirectory(srcDir, destDir string) error {
+func (c *Client) copyDirectory(srcDir, destDir string) error {
 	return filepath.WalkDir(srcDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -199,7 +201,13 @@ func copyDirectory(srcDir, destDir string) error {
 			return fmt.Errorf("reading %s: %w", path, err)
 		}
 
-		return os.WriteFile(destPath, data, 0644)
+		if err := os.WriteFile(destPath, data, 0644); err != nil {
+			return err
+		}
+		if c.OnProgress != nil {
+			c.OnProgress(rel)
+		}
+		return nil
 	})
 }
 
@@ -231,6 +239,9 @@ func (c *Client) downloadGitHubDirectory(source *RepoSource, dirPath, destDir st
 			downloadURL := source.ResolveDownloadURL(entry.Path)
 			if err := c.Download(downloadURL, destPath, source.Token, source.Username); err != nil {
 				return fmt.Errorf("downloading %s: %w", entry.Name, err)
+			}
+			if c.OnProgress != nil {
+				c.OnProgress(entry.Name)
 			}
 		}
 	}


### PR DESCRIPTION
Closes #79

## Summary
- Add `OnProgress` callback to `Client` that fires for each file downloaded in directory mode
- Wire it to verbose output in installer: `--verbose` now shows each file as it downloads

## Changes
- `internal/registry/client.go` — `OnProgress` field on `Client`, called in `copyDirectory()` and `downloadGitHubDirectory()`
- `internal/installer/install.go` — set `OnProgress` to log each file via verbose callback

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)