### PR TITLE
feat: concurrent file downloads for GitHub directory mode

### DIFF
--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -219,6 +220,9 @@ func (c *Client) copyDirectory(srcDir, destDir string) error {
 	})
 }
 
+// maxConcurrentDownloads limits the number of concurrent file downloads.
+const maxConcurrentDownloads = 8
+
 func (c *Client) downloadGitHubDirectory(source *RepoSource, dirPath, destDir string) error {
 	apiURL := source.ContentsAPIURL(dirPath)
 
@@ -232,29 +236,66 @@ func (c *Client) downloadGitHubDirectory(source *RepoSource, dirPath, destDir st
 		return fmt.Errorf("parsing directory listing for %s: %w", dirPath, err)
 	}
 
+	// Separate directories and files
+	var dirs, files []githubContentEntry
 	for _, entry := range entries {
-		destPath := filepath.Join(destDir, entry.Name)
-
 		switch entry.Type {
 		case "dir":
-			if err := os.MkdirAll(destPath, 0755); err != nil {
-				return fmt.Errorf("creating directory %s: %w", destPath, err)
-			}
-			if err := c.downloadGitHubDirectory(source, entry.Path, destPath); err != nil {
-				return err
-			}
+			dirs = append(dirs, entry)
 		case "file":
+			files = append(files, entry)
+		}
+	}
+
+	// Create directories and recurse (sequential — dirs must exist before files)
+	for _, entry := range dirs {
+		destPath := filepath.Join(destDir, entry.Name)
+		if err := os.MkdirAll(destPath, 0755); err != nil {
+			return fmt.Errorf("creating directory %s: %w", destPath, err)
+		}
+		if err := c.downloadGitHubDirectory(source, entry.Path, destPath); err != nil {
+			return err
+		}
+	}
+
+	// Download files concurrently with bounded worker pool
+	sem := make(chan struct{}, maxConcurrentDownloads)
+	var mu sync.Mutex
+	var firstErr error
+	var wg sync.WaitGroup
+
+	for _, entry := range files {
+		wg.Add(1)
+		go func(entry githubContentEntry) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			mu.Lock()
+			if firstErr != nil {
+				mu.Unlock()
+				return
+			}
+			mu.Unlock()
+
+			destPath := filepath.Join(destDir, entry.Name)
 			downloadURL := source.ResolveDownloadURL(entry.Path)
 			if err := c.Download(downloadURL, destPath, source.Token, source.Username); err != nil {
-				return fmt.Errorf("downloading %s: %w", entry.Name, err)
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("downloading %s: %w", entry.Name, err)
+				}
+				mu.Unlock()
+				return
 			}
 			if c.OnProgress != nil {
 				c.OnProgress(entry.Name)
 			}
-		}
+		}(entry)
 	}
 
-	return nil
+	wg.Wait()
+	return firstErr
 }
 
 func (c *Client) newRequest(rawURL, token, username string) (*http.Request, error) {

--- a/internal/registry/client_test.go
+++ b/internal/registry/client_test.go
@@ -1,12 +1,15 @@
 package registry
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestFetchIndexLocal(t *testing.T) {
@@ -375,6 +378,70 @@ func TestDownloadDirectoryGitHub(t *testing.T) {
 	}
 	if string(data) != `{"name":"test-skill"}` {
 		t.Errorf("unexpected content: %q", string(data))
+	}
+}
+
+func TestDownloadDirectoryGitHubConcurrent(t *testing.T) {
+	var concurrent atomic.Int32
+	var maxConcurrent atomic.Int32
+
+	fileCount := 12
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/api/v3/repos/owner/repo/contents/skills/many-files" {
+			var entries []string
+			for i := range fileCount {
+				entries = append(entries, fmt.Sprintf(`{"name":"file%d.txt","path":"skills/many-files/file%d.txt","type":"file"}`, i, i))
+			}
+			resp := "[" + strings.Join(entries, ",") + "]"
+			if _, err := w.Write([]byte(resp)); err != nil {
+				t.Errorf("writing response: %v", err)
+			}
+			return
+		}
+
+		// Track concurrency for file downloads
+		cur := concurrent.Add(1)
+		defer concurrent.Add(-1)
+		for {
+			old := maxConcurrent.Load()
+			if cur <= old || maxConcurrent.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+
+		// Small delay so concurrent requests overlap
+		time.Sleep(10 * time.Millisecond)
+
+		if _, err := w.Write([]byte("content")); err != nil {
+			t.Errorf("writing response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	source := &RepoSource{
+		Name:   "test",
+		URL:    server.URL + "/owner/repo",
+		Branch: "main",
+	}
+
+	destDir := t.TempDir()
+	client := NewClient()
+	if err := client.DownloadDirectory(source, "skills/many-files/", destDir); err != nil {
+		t.Fatalf("DownloadDirectory: %v", err)
+	}
+
+	// Verify all files downloaded
+	for i := range fileCount {
+		name := fmt.Sprintf("file%d.txt", i)
+		if _, err := os.Stat(filepath.Join(destDir, name)); err != nil {
+			t.Errorf("missing %s: %v", name, err)
+		}
+	}
+
+	if got := maxConcurrent.Load(); got < 2 {
+		t.Errorf("expected concurrent downloads, but max concurrency was %d", got)
 	}
 }
 


### PR DESCRIPTION
Closes #77

## Summary
- Use bounded worker pool (8 concurrent goroutines) to download files in parallel within `downloadGitHubDirectory`
- Directories are still processed sequentially (must exist before files download into them)
- No new dependencies — uses stdlib `sync.WaitGroup` + semaphore channel

## Changes
- `internal/registry/client.go` — refactor `downloadGitHubDirectory()` to separate dirs/files, download files concurrently with `maxConcurrentDownloads` semaphore
- `internal/registry/client_test.go` — add `TestDownloadDirectoryGitHubConcurrent` verifying parallel downloads

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
