### PR TITLE
fix: --global installs to home directory instead of project root

### DIFF
--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -169,8 +169,11 @@ func (inst *Installer) Install(name string, force bool, global bool) error {
 		if err != nil {
 			return err
 		}
-		projectRoot := storage.DetectProjectRoot()
-		finalDir = filepath.Join(projectRoot, agent.SkillsPath, name)
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("detecting home directory: %w", err)
+		}
+		finalDir = filepath.Join(home, agent.SkillsPath, name)
 	} else {
 		finalDir = inst.Paths.SkillDir(name)
 	}


### PR DESCRIPTION
Closes #90

## Summary
- `--global` now installs to `~/.claude/skills/` instead of `{git-project-root}/.claude/skills/`
- Changed `storage.DetectProjectRoot()` to `os.UserHomeDir()` in the global install path

## Changes
- `internal/installer/install.go` — use `os.UserHomeDir()` instead of `storage.DetectProjectRoot()` when `--global` is set

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)