### PR TITLE
feat: add shorthand flags for commonly used options

### DIFF
--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -95,8 +95,8 @@ var createCmd = &cobra.Command{
 }
 
 func init() {
-	createCmd.Flags().StringVar(&createType, "type", "prompt", "skill type (prompt, shell, python, node)")
-	createCmd.Flags().StringVar(&createAuthor, "author", "", "author name")
+	createCmd.Flags().StringVarP(&createType, "type", "t", "prompt", "skill type (prompt, shell, python, node)")
+	createCmd.Flags().StringVarP(&createAuthor, "author", "a", "", "author name")
 	createCmd.Flags().StringVar(&createDescription, "description", "", "skill description")
 	rootCmd.AddCommand(createCmd)
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -32,9 +32,9 @@ var installCmd = &cobra.Command{
 }
 
 func init() {
-	installCmd.Flags().BoolVar(&forceInstall, "force", false, "force reinstall if already installed")
+	installCmd.Flags().BoolVarP(&forceInstall, "force", "f", false, "force reinstall if already installed")
 	installCmd.Flags().BoolVarP(&globalInstall, "global", "g", false, "install to agent skills directory in home")
-	installCmd.Flags().StringVar(&installTool, "tool", "claude", "agent type for --global install path (claude, cursor, windsurf, cline, generic)")
+	installCmd.Flags().StringVarP(&installTool, "tool", "t", "claude", "agent type for --global install path (claude, cursor, windsurf, cline, generic)")
 	installCmd.Flags().StringVar(&installVersion, "version", "", "install a specific version")
 	rootCmd.AddCommand(installCmd)
 }

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -81,7 +81,7 @@ var lintCmd = &cobra.Command{
 }
 
 func init() {
-	lintCmd.Flags().BoolVar(&lintStrict, "strict", false, "treat warnings as errors")
+	lintCmd.Flags().BoolVarP(&lintStrict, "strict", "s", false, "treat warnings as errors")
 	rootCmd.AddCommand(lintCmd)
 }
 

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -159,10 +159,10 @@ var publishCmd = &cobra.Command{
 }
 
 func init() {
-	publishCmd.Flags().StringVar(&publishRepo, "repo", "", "target registry name")
+	publishCmd.Flags().StringVarP(&publishRepo, "repo", "r", "", "target registry name")
 	publishCmd.Flags().StringVar(&publishVersion, "version", "", "override version from skill.json")
 	publishCmd.Flags().StringVar(&publishToken, "token", "", "GitHub personal access token (overrides config)")
-	publishCmd.Flags().BoolVar(&publishForce, "force", false, "overwrite existing version")
-	publishCmd.Flags().BoolVar(&publishDryRun, "dry-run", false, "validate without uploading")
+	publishCmd.Flags().BoolVarP(&publishForce, "force", "f", false, "overwrite existing version")
+	publishCmd.Flags().BoolVarP(&publishDryRun, "dry-run", "n", false, "validate without uploading")
 	rootCmd.AddCommand(publishCmd)
 }

--- a/internal/cli/repo_index.go
+++ b/internal/cli/repo_index.go
@@ -113,8 +113,8 @@ var repoIndexCmd = &cobra.Command{
 }
 
 func init() {
-	repoIndexCmd.Flags().StringVar(&repoIndexMerge, "merge", "", "merge with existing index file")
-	repoIndexCmd.Flags().StringVar(&repoIndexURL, "url", "", "base URL prefix for download_url fields")
+	repoIndexCmd.Flags().StringVarP(&repoIndexMerge, "merge", "m", "", "merge with existing index file")
+	repoIndexCmd.Flags().StringVarP(&repoIndexURL, "url", "u", "", "base URL prefix for download_url fields")
 	repoIndexCmd.Flags().StringVarP(&repoIndexOutput, "output", "o", "", "output path for index.json (default: <dir>/index.json)")
 	repoCmd.AddCommand(repoIndexCmd)
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -31,7 +31,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&homeDir, "home", "", "skillhub home directory (default: ~/.skillhub)")
-	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "enable verbose output")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
 }
 
 func Execute() error {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -61,6 +61,6 @@ var runCmd = &cobra.Command{
 }
 
 func init() {
-	runCmd.Flags().StringVar(&toolFlag, "tool", "", "agent type (claude, cursor, windsurf, cline, generic)")
+	runCmd.Flags().StringVarP(&toolFlag, "tool", "t", "", "agent type (claude, cursor, windsurf, cline, generic)")
 	rootCmd.AddCommand(runCmd)
 }

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -85,6 +85,6 @@ var searchCmd = &cobra.Command{
 
 func init() {
 	searchCmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "output format (table, json, yaml)")
-	searchCmd.Flags().BoolVar(&searchVersions, "versions", false, "show all available versions")
+	searchCmd.Flags().BoolVarP(&searchVersions, "versions", "V", false, "show all available versions")
 	rootCmd.AddCommand(searchCmd)
 }


### PR DESCRIPTION
Closes #92

## Summary
- Add single-letter shorthands for frequently used flags across all commands

## Shorthands added

| Command | Flag | Short |
|---------|------|-------|
| (global) | `--verbose` | `-v` |
| install | `--global` | `-g` |
| install | `--force` | `-f` |
| install | `--tool` | `-t` |
| publish | `--repo` | `-r` |
| publish | `--force` | `-f` |
| publish | `--dry-run` | `-n` |
| create | `--type` | `-t` |
| create | `--author` | `-a` |
| run | `--tool` | `-t` |
| lint | `--strict` | `-s` |
| repo index | `--merge` | `-m` |
| repo index | `--url` | `-u` |
| search | `--versions` | `-V` |

## Changes
- `internal/cli/root.go`, `install.go`, `publish.go`, `create.go`, `run.go`, `lint.go`, `repo_index.go`, `search.go` — `BoolVar`/`StringVar` → `BoolVarP`/`StringVarP`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)