### PR TITLE
feat: add --repo filter flag to search and install (#96)

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -11,6 +11,7 @@ var (
 	globalInstall  bool
 	installTool    string
 	installVersion string
+	installRepo    string
 )
 
 var installCmd = &cobra.Command{
@@ -27,6 +28,7 @@ var installCmd = &cobra.Command{
 		inst.Verbose = logVerbose
 		inst.AgentTool = installTool
 		inst.Version = installVersion
+		inst.RepoFilter = installRepo
 		return inst.Install(args[0], forceInstall, globalInstall)
 	},
 }
@@ -36,5 +38,6 @@ func init() {
 	installCmd.Flags().BoolVarP(&globalInstall, "global", "g", false, "install to agent skills directory in home")
 	installCmd.Flags().StringVarP(&installTool, "tool", "t", "claude", "agent type for --global install path (claude, cursor, windsurf, cline, generic)")
 	installCmd.Flags().StringVar(&installVersion, "version", "", "install a specific version")
+	installCmd.Flags().StringVarP(&installRepo, "repo", "r", "", "install from a specific registry")
 	rootCmd.AddCommand(installCmd)
 }

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -10,7 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var searchVersions bool
+var (
+	searchVersions bool
+	searchRepo     string
+)
 
 var searchCmd = &cobra.Command{
 	Use:   "search [query]",
@@ -22,13 +25,9 @@ var searchCmd = &cobra.Command{
 			return err
 		}
 
-		if len(cfg.Registries) == 0 {
-			return fmt.Errorf("no registries configured; use 'skillhub repo add' to add one")
-		}
-
-		sources := make([]registry.RepoSource, len(cfg.Registries))
-		for i, r := range cfg.Registries {
-			sources[i] = registry.RepoSource{Name: r.Name, URL: r.URL, Token: r.Token, Username: r.Username, Branch: r.Branch}
+		sources, err := registrySources(cfg, searchRepo)
+		if err != nil {
+			return err
 		}
 
 		client := registry.NewClient()
@@ -67,15 +66,25 @@ var searchCmd = &cobra.Command{
 			return nil
 		}
 
+		multiRegistry := len(cfg.Registries) > 1
+
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-		fmt.Fprintln(w, "NAME\tVERSION\tDESCRIPTION")
+		if multiRegistry {
+			fmt.Fprintln(w, "NAME\tVERSION\tREGISTRY\tDESCRIPTION")
+		} else {
+			fmt.Fprintln(w, "NAME\tVERSION\tDESCRIPTION")
+		}
 		for _, r := range results {
 			desc := r.Description
 			runes := []rune(desc)
 			if len(runes) > 60 {
 				desc = string(runes[:57]) + "..."
 			}
-			fmt.Fprintf(w, "%s\t%s\t%s\n", r.Name, r.Version, desc)
+			if multiRegistry {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", r.Name, r.Version, r.Registry, desc)
+			} else {
+				fmt.Fprintf(w, "%s\t%s\t%s\n", r.Name, r.Version, desc)
+			}
 		}
 		w.Flush()
 
@@ -86,5 +95,6 @@ var searchCmd = &cobra.Command{
 func init() {
 	searchCmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "output format (table, json, yaml)")
 	searchCmd.Flags().BoolVarP(&searchVersions, "versions", "V", false, "show all available versions")
+	searchCmd.Flags().StringVarP(&searchRepo, "repo", "r", "", "filter by registry name")
 	rootCmd.AddCommand(searchCmd)
 }

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -10,6 +10,35 @@ import (
 	"github.com/jayl2kor/skillhub/internal/registry"
 )
 
+// registrySources converts config registries to RepoSource slice.
+// If repoFilter is non-empty, only the matching registry is returned.
+func registrySources(cfg *config.Config, repoFilter string) ([]registry.RepoSource, error) {
+	if len(cfg.Registries) == 0 {
+		return nil, fmt.Errorf("no registries configured; use 'skillhub repo add' to add one")
+	}
+
+	var entries []config.RegistryEntry
+	if repoFilter != "" {
+		for _, r := range cfg.Registries {
+			if r.Name == repoFilter {
+				entries = append(entries, r)
+				break
+			}
+		}
+		if len(entries) == 0 {
+			return nil, fmt.Errorf("registry %q not found; check 'skillhub repo list'", repoFilter)
+		}
+	} else {
+		entries = cfg.Registries
+	}
+
+	sources := make([]registry.RepoSource, len(entries))
+	for i, r := range entries {
+		sources[i] = registry.RepoSource{Name: r.Name, URL: r.URL, Token: r.Token, Username: r.Username, Branch: r.Branch}
+	}
+	return sources, nil
+}
+
 func loadOrSetupConfig() (*config.Config, error) {
 	cfg, err := config.Load(paths.Config)
 	if err == nil {

--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -13,12 +13,13 @@ import (
 )
 
 type Installer struct {
-	Paths     *storage.Paths
-	Config    *config.Config
-	Client    *registry.Client
-	Verbose   func(format string, args ...any)
-	AgentTool string // agent type for --global install path (default: "claude")
-	Version   string // specific version to install (empty = latest)
+	Paths      *storage.Paths
+	Config     *config.Config
+	Client     *registry.Client
+	Verbose    func(format string, args ...any)
+	AgentTool  string // agent type for --global install path (default: "claude")
+	Version    string // specific version to install (empty = latest)
+	RepoFilter string // filter by registry name (empty = all)
 }
 
 func NewInstaller(paths *storage.Paths, cfg *config.Config) *Installer {
@@ -43,14 +44,29 @@ func (inst *Installer) Install(name string, force bool, global bool) error {
 		return fmt.Errorf("skill %q is already installed (use --force to reinstall)", name)
 	}
 
-	// 2. Build registry sources
-	sources := make([]registry.RepoSource, len(inst.Config.Registries))
-	for i, r := range inst.Config.Registries {
-		sources[i] = registry.RepoSource{Name: r.Name, URL: r.URL, Token: r.Token, Username: r.Username, Branch: r.Branch}
+	// 2. Build registry sources (optionally filtered by RepoFilter)
+	var entries []config.RegistryEntry
+	if inst.RepoFilter != "" {
+		for _, r := range inst.Config.Registries {
+			if r.Name == inst.RepoFilter {
+				entries = append(entries, r)
+				break
+			}
+		}
+		if len(entries) == 0 {
+			return fmt.Errorf("registry %q not found; check 'skillhub repo list'", inst.RepoFilter)
+		}
+	} else {
+		entries = inst.Config.Registries
 	}
 
-	if len(sources) == 0 {
+	if len(entries) == 0 {
 		return fmt.Errorf("no registries configured; use 'skillhub repo add' to add one")
+	}
+
+	sources := make([]registry.RepoSource, len(entries))
+	for i, r := range entries {
+		sources[i] = registry.RepoSource{Name: r.Name, URL: r.URL, Token: r.Token, Username: r.Username, Branch: r.Branch}
 	}
 
 	// 3. Fetch and merge all indexes


### PR DESCRIPTION
## Summary
- Add `-r, --repo <name>` flag to `search` and `install` commands to filter by a specific registry
- Show `REGISTRY` column in `search` table output when multiple registries are configured
- Extract shared `registrySources()` helper to convert config registries to RepoSource slice with optional filtering
- Add `RepoFilter` field to `Installer` struct for install-time filtering

## Test plan
- [ ] `skillhub search -r skill-repo` returns only skills from that registry
- [ ] `skillhub search -r nonexistent` returns clear error
- [ ] `skillhub install skill-name -r skill-repo` installs from specified registry
- [ ] `skillhub search` (no flag) works as before
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)