### PR TITLE
feat: make publish destination prefix configurable (#94)

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -17,6 +17,7 @@ var (
 	publishToken   string
 	publishForce   bool
 	publishDryRun  bool
+	publishPrefix  string
 )
 
 var publishCmd = &cobra.Command{
@@ -70,6 +71,7 @@ var publishCmd = &cobra.Command{
 		}
 
 		var reg *registry.RepoSource
+		var configSkillsPrefix string
 		if publishRepo != "" {
 			for _, r := range cfg.Registries {
 				if r.Name == publishRepo {
@@ -80,6 +82,7 @@ var publishCmd = &cobra.Command{
 						Username: r.Username,
 						Branch:   r.Branch,
 					}
+					configSkillsPrefix = r.SkillsPrefix
 					break
 				}
 			}
@@ -95,6 +98,7 @@ var publishCmd = &cobra.Command{
 				Username: r.Username,
 				Branch:   r.Branch,
 			}
+			configSkillsPrefix = r.SkillsPrefix
 		} else {
 			return fmt.Errorf("multiple registries configured; use --repo to specify")
 		}
@@ -105,8 +109,15 @@ var publishCmd = &cobra.Command{
 			reg.Token = publishToken
 		}
 
-		// Directory path in registry: skills/{name}/
-		destPrefix := "skills/" + m.Name
+		// Resolve skills prefix: --prefix flag > per-registry config > default
+		skillsPrefix := ".claude/skills"
+		if configSkillsPrefix != "" {
+			skillsPrefix = configSkillsPrefix
+		}
+		if publishPrefix != "" {
+			skillsPrefix = publishPrefix
+		}
+		destPrefix := skillsPrefix + "/" + m.Name
 
 		if publishDryRun {
 			fmt.Printf("[dry-run] Would publish %s@%s to %s (%s/)\n", m.Name, m.Version, reg.Name, destPrefix)
@@ -164,5 +175,6 @@ func init() {
 	publishCmd.Flags().StringVar(&publishToken, "token", "", "GitHub personal access token (overrides config)")
 	publishCmd.Flags().BoolVarP(&publishForce, "force", "f", false, "overwrite existing version")
 	publishCmd.Flags().BoolVarP(&publishDryRun, "dry-run", "n", false, "validate without uploading")
+	publishCmd.Flags().StringVar(&publishPrefix, "prefix", "", "destination prefix in registry (default: .claude/skills)")
 	rootCmd.AddCommand(publishCmd)
 }

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -44,7 +44,8 @@ var repoAddCmd = &cobra.Command{
 			return fmt.Errorf("cannot access registry index: %w", err)
 		}
 
-		if err := cfg.AddRegistry(source.Name, source.URL, source.Token, source.Username, source.Branch); err != nil {
+		skillsPrefix, _ := cmd.Flags().GetString("skills-prefix")
+		if err := cfg.AddRegistry(source.Name, source.URL, source.Token, source.Username, source.Branch, skillsPrefix); err != nil {
 			return err
 		}
 
@@ -108,6 +109,7 @@ var repoRemoveCmd = &cobra.Command{
 func init() {
 	repoAddCmd.Flags().String("token", "", "personal access token for private registries")
 	repoAddCmd.Flags().String("username", "", "username for Basic Auth (required for GitHub Enterprise)")
+	repoAddCmd.Flags().String("skills-prefix", "", "destination prefix for publish (default: .claude/skills)")
 	repoCmd.AddCommand(repoAddCmd)
 	repoCmd.AddCommand(repoListCmd)
 	repoCmd.AddCommand(repoRemoveCmd)

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -65,14 +65,14 @@ func loadOrSetupConfig() (*config.Config, error) {
 				forceAnswer, _ := reader.ReadString('\n')
 				forceAnswer = strings.TrimSpace(forceAnswer)
 				if strings.ToLower(forceAnswer) == "y" {
-					if err := cfg.AddRegistry(source.Name, source.URL, source.Token, source.Username, source.Branch); err != nil {
+					if err := cfg.AddRegistry(source.Name, source.URL, source.Token, source.Username, source.Branch, ""); err != nil {
 						fmt.Fprintf(os.Stderr, "Warning: failed to add registry (%v)\n", err)
 					} else {
 						fmt.Printf("Added registry '%s'.\n", source.Name)
 					}
 				}
 			} else {
-				if err := cfg.AddRegistry(source.Name, source.URL, source.Token, source.Username, source.Branch); err != nil {
+				if err := cfg.AddRegistry(source.Name, source.URL, source.Token, source.Username, source.Branch, ""); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: failed to add registry (%v)\n", err)
 				} else {
 					fmt.Printf("Added registry '%s'.\n", source.Name)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,11 +9,12 @@ import (
 )
 
 type RegistryEntry struct {
-	Name     string `yaml:"name"`
-	URL      string `yaml:"url"`
-	Token    string `yaml:"token,omitempty"`
-	Username string `yaml:"username,omitempty"`
-	Branch   string `yaml:"branch,omitempty"`
+	Name         string `yaml:"name"`
+	URL          string `yaml:"url"`
+	Token        string `yaml:"token,omitempty"`
+	Username     string `yaml:"username,omitempty"`
+	Branch       string `yaml:"branch,omitempty"`
+	SkillsPrefix string `yaml:"skills_prefix,omitempty"`
 }
 
 type Config struct {
@@ -71,17 +72,18 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func (c *Config) AddRegistry(name, url, token, username, branch string) error {
+func (c *Config) AddRegistry(name, url, token, username, branch, skillsPrefix string) error {
 	for i, r := range c.Registries {
 		if r.Name == name {
 			c.Registries[i].URL = url
 			c.Registries[i].Token = token
 			c.Registries[i].Username = username
 			c.Registries[i].Branch = branch
+			c.Registries[i].SkillsPrefix = skillsPrefix
 			return nil
 		}
 	}
-	c.Registries = append(c.Registries, RegistryEntry{Name: name, URL: url, Token: token, Username: username, Branch: branch})
+	c.Registries = append(c.Registries, RegistryEntry{Name: name, URL: url, Token: token, Username: username, Branch: branch, SkillsPrefix: skillsPrefix})
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -96,7 +96,7 @@ func TestValidate(t *testing.T) {
 func TestAddRemoveRegistry(t *testing.T) {
 	cfg := &Config{}
 
-	if err := cfg.AddRegistry("test", "https://example.com", "", "", ""); err != nil {
+	if err := cfg.AddRegistry("test", "https://example.com", "", "", "", ""); err != nil {
 		t.Fatalf("AddRegistry: %v", err)
 	}
 
@@ -105,7 +105,7 @@ func TestAddRemoveRegistry(t *testing.T) {
 	}
 
 	// Duplicate name should update URL, token, and username
-	if err := cfg.AddRegistry("test", "https://other.com", "tok", "user1", ""); err != nil {
+	if err := cfg.AddRegistry("test", "https://other.com", "tok", "user1", "", ""); err != nil {
 		t.Fatalf("AddRegistry update: %v", err)
 	}
 	if len(cfg.Registries) != 1 {

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -63,7 +63,7 @@ func TestFullWorkflow(t *testing.T) {
 
 	// Step 2: Create config with registry
 	cfg := config.DefaultConfig(homeDir)
-	if err := cfg.AddRegistry("test-reg", regDir, "", "", ""); err != nil {
+	if err := cfg.AddRegistry("test-reg", regDir, "", "", "", ""); err != nil {
 		t.Fatal(err)
 	}
 	if err := cfg.Save(paths.Config); err != nil {


### PR DESCRIPTION
## Summary
- Change default publish destination from `skills/<name>/` to `.claude/skills/<name>/`
- Add `--prefix` flag to `publish` command to override destination prefix
- Add `skills_prefix` field to per-registry config (`RegistryEntry`)
- Add `--skills-prefix` flag to `repo add` for per-registry configuration
- Resolution order: `--prefix` flag > per-registry config > default (`.claude/skills`)

## Test plan
- [ ] `skillhub publish --dry-run` shows `.claude/skills/<name>/` prefix
- [ ] `skillhub publish --prefix custom/path --dry-run` shows `custom/path/<name>/`
- [ ] `skillhub repo add --help` shows `--skills-prefix` flag
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)