### PR TITLE
refactor: apply Go Code Review Comments conventions

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -89,9 +89,11 @@ var doctorCmd = &cobra.Command{
 		// Check registries
 		fmt.Print("Registries... ")
 		cfg, err := config.Load(paths.Config)
-		if err == nil && len(cfg.Registries) > 0 {
+		if err != nil {
+			fmt.Println("SKIPPED (config load error)")
+		} else if len(cfg.Registries) > 0 {
 			fmt.Printf("%d configured\n", len(cfg.Registries))
-		} else if err == nil {
+		} else {
 			fmt.Println("none configured")
 		}
 

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -66,7 +66,7 @@ var infoCmd = &cobra.Command{
 		}
 
 		client := registry.NewClient()
-		idx, err := client.FetchAllIndexes(sources)
+		idx, err := client.FetchAllIndexes(cmd.Context(), sources)
 		if err != nil {
 			return fmt.Errorf("fetching indexes: %w", err)
 		}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -29,7 +29,7 @@ var installCmd = &cobra.Command{
 		inst.AgentTool = installTool
 		inst.Version = installVersion
 		inst.RepoFilter = installRepo
-		return inst.Install(args[0], forceInstall, globalInstall)
+		return inst.Install(cmd.Context(), args[0], forceInstall, globalInstall)
 	},
 }
 

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -17,7 +17,11 @@ func printFormatted(data any) error {
 		enc.SetIndent("", "  ")
 		return enc.Encode(data)
 	case "yaml":
-		return yaml.NewEncoder(os.Stdout).Encode(data)
+		enc := yaml.NewEncoder(os.Stdout)
+		if err := enc.Encode(data); err != nil {
+			return err
+		}
+		return enc.Close()
 	default:
 		return fmt.Errorf("unsupported output format %q", outputFormat)
 	}

--- a/internal/cli/package.go
+++ b/internal/cli/package.go
@@ -84,18 +84,30 @@ func init() {
 	rootCmd.AddCommand(packageCmd)
 }
 
-func createTarGz(srcDir, destPath, prefix string) error {
+func createTarGz(srcDir, destPath, prefix string) (err error) {
 	outFile, err := os.Create(destPath)
 	if err != nil {
 		return fmt.Errorf("creating output file: %w", err)
 	}
-	defer outFile.Close()
+	defer func() {
+		if cerr := outFile.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing output file: %w", cerr)
+		}
+	}()
 
 	gw := gzip.NewWriter(outFile)
-	defer gw.Close()
+	defer func() {
+		if cerr := gw.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing gzip writer: %w", cerr)
+		}
+	}()
 
 	tw := tar.NewWriter(gw)
-	defer tw.Close()
+	defer func() {
+		if cerr := tw.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing tar writer: %w", cerr)
+		}
+	}()
 
 	srcDir, err = filepath.Abs(srcDir)
 	if err != nil {

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -132,7 +132,7 @@ var publishCmd = &cobra.Command{
 
 		// Check version conflict via index
 		if !publishForce {
-			idx, err := client.FetchIndex(reg)
+			idx, err := client.FetchIndex(cmd.Context(), reg)
 			if err == nil {
 				if existing := idx.FindVersion(m.Name, m.Version); existing != nil {
 					return fmt.Errorf("version %s@%s already exists in %s (use --force to overwrite)", m.Name, m.Version, reg.Name)
@@ -148,7 +148,7 @@ var publishCmd = &cobra.Command{
 			}
 		}
 
-		if err := client.UploadDirectory(reg, dir, destPrefix, commitMsg); err != nil {
+		if err := client.UploadDirectory(cmd.Context(), reg, dir, destPrefix, commitMsg); err != nil {
 			return fmt.Errorf("uploading skill directory: %w", err)
 		}
 
@@ -160,7 +160,7 @@ var publishCmd = &cobra.Command{
 			Tags:        m.Tags,
 			DownloadURL: destPrefix + "/",
 		}
-		if err := client.UpdateIndex(reg, entry, publishForce); err != nil {
+		if err := client.UpdateIndex(cmd.Context(), reg, entry, publishForce); err != nil {
 			return fmt.Errorf("updating index: %w", err)
 		}
 

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -40,7 +40,7 @@ var pullCmd = &cobra.Command{
 		}
 
 		client := registry.NewClient()
-		idx, err := client.FetchAllIndexes(sources)
+		idx, err := client.FetchAllIndexes(cmd.Context(), sources)
 		if err != nil {
 			return fmt.Errorf("fetching indexes: %w", err)
 		}
@@ -85,7 +85,7 @@ var pullCmd = &cobra.Command{
 			}
 
 			logVerbose("downloading directory %s", entry.DownloadURL)
-			if err := client.DownloadDirectory(matchedSource, entry.DownloadURL, destPath); err != nil {
+			if err := client.DownloadDirectory(cmd.Context(), matchedSource, entry.DownloadURL, destPath); err != nil {
 				return fmt.Errorf("downloading skill directory: %w", err)
 			}
 
@@ -96,7 +96,7 @@ var pullCmd = &cobra.Command{
 			destPath := filepath.Join(pullDest, filename)
 
 			logVerbose("downloading %s", downloadURL)
-			if err := client.Download(downloadURL, destPath, token, username); err != nil {
+			if err := client.Download(cmd.Context(), downloadURL, destPath, token, username); err != nil {
 				return fmt.Errorf("downloading skill: %w", err)
 			}
 

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -37,10 +37,10 @@ var repoAddCmd = &cobra.Command{
 
 		// Detect default branch
 		client := registry.NewClient()
-		source.Branch = client.DetectDefaultBranch(source)
+		source.Branch = client.DetectDefaultBranch(cmd.Context(), source)
 
 		// Verify index is accessible
-		if _, err := client.FetchIndex(source); err != nil {
+		if _, err := client.FetchIndex(cmd.Context(), source); err != nil {
 			return fmt.Errorf("cannot access registry index: %w", err)
 		}
 

--- a/internal/cli/repo_update.go
+++ b/internal/cli/repo_update.go
@@ -44,7 +44,7 @@ var repoUpdateCmd = &cobra.Command{
 			}
 
 			logVerbose("fetching index from %s", r.Name)
-			idx, err := client.FetchIndex(src)
+			idx, err := client.FetchIndex(cmd.Context(), src)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "WARNING: failed to update %q: %v\n", r.Name, err)
 				continue

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -34,6 +34,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
 }
 
+// Execute runs the root cobra command and returns any error.
 func Execute() error {
 	return rootCmd.Execute()
 }

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -32,7 +32,7 @@ var searchCmd = &cobra.Command{
 
 		client := registry.NewClient()
 		logVerbose("fetching indexes from %d registry(ies)", len(sources))
-		idx, err := client.FetchAllIndexes(sources)
+		idx, err := client.FetchAllIndexes(cmd.Context(), sources)
 		if err != nil {
 			return fmt.Errorf("fetching indexes: %w", err)
 		}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -73,7 +74,9 @@ func loadOrSetupConfig() (*config.Config, error) {
 		source, err := registry.ParseRepoURL(repoURL)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to parse URL (%v), skipping registry.\n", err)
-		} else {
+		}
+
+		if err == nil {
 			fmt.Print("Enter token (press Enter to skip): ")
 			token, _ := reader.ReadString('\n')
 			token = strings.TrimSpace(token)
@@ -87,20 +90,18 @@ func loadOrSetupConfig() (*config.Config, error) {
 			}
 
 			client := registry.NewClient()
-			source.Branch = client.DetectDefaultBranch(source)
-			if _, err := client.FetchIndex(source); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: cannot access registry index (%v)\n", err)
+			setupCtx := context.Background()
+			source.Branch = client.DetectDefaultBranch(setupCtx, source)
+
+			addRegistry := true
+			if _, fetchErr := client.FetchIndex(setupCtx, source); fetchErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: cannot access registry index (%v)\n", fetchErr)
 				fmt.Print("Add the registry anyway? [y/N]: ")
 				forceAnswer, _ := reader.ReadString('\n')
-				forceAnswer = strings.TrimSpace(forceAnswer)
-				if strings.ToLower(forceAnswer) == "y" {
-					if err := cfg.AddRegistry(source.Name, source.URL, source.Token, source.Username, source.Branch, ""); err != nil {
-						fmt.Fprintf(os.Stderr, "Warning: failed to add registry (%v)\n", err)
-					} else {
-						fmt.Printf("Added registry '%s'.\n", source.Name)
-					}
-				}
-			} else {
+				addRegistry = strings.ToLower(strings.TrimSpace(forceAnswer)) == "y"
+			}
+
+			if addRegistry {
 				if err := cfg.AddRegistry(source.Name, source.URL, source.Token, source.Username, source.Branch, ""); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: failed to add registry (%v)\n", err)
 				} else {

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -162,7 +163,8 @@ func resolveSkillDir(name string) (dir string, cleanup func(), err error) {
 	}
 
 	client := registry.NewClient()
-	idx, err := client.FetchAllIndexes(sources)
+	ctx := context.Background()
+	idx, err := client.FetchAllIndexes(ctx, sources)
 	if err != nil {
 		return "", noop, fmt.Errorf("fetching indexes: %w", err)
 	}
@@ -209,7 +211,7 @@ func resolveSkillDir(name string) (dir string, cleanup func(), err error) {
 			return "", noop, fmt.Errorf("registry source not found for skill %q", name)
 		}
 		logVerbose("downloading directory %s", entry.DownloadURL)
-		if err := client.DownloadDirectory(matchedSource, entry.DownloadURL, extractDir); err != nil {
+		if err := client.DownloadDirectory(ctx, matchedSource, entry.DownloadURL, extractDir); err != nil {
 			cleanupFn()
 			return "", noop, fmt.Errorf("downloading skill directory: %w", err)
 		}
@@ -217,7 +219,7 @@ func resolveSkillDir(name string) (dir string, cleanup func(), err error) {
 		// Archive mode
 		archivePath := filepath.Join(tmpDir, "archive.tar.gz")
 		logVerbose("downloading %s", downloadURL)
-		if err := client.Download(downloadURL, archivePath, token, username); err != nil {
+		if err := client.Download(ctx, downloadURL, archivePath, token, username); err != nil {
 			cleanupFn()
 			return "", noop, fmt.Errorf("downloading skill: %w", err)
 		}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -30,7 +30,7 @@ var updateCmd = &cobra.Command{
 		}
 
 		client := registry.NewClient()
-		idx, err := client.FetchAllIndexes(sources)
+		idx, err := client.FetchAllIndexes(cmd.Context(), sources)
 		if err != nil {
 			return fmt.Errorf("fetching indexes: %w", err)
 		}
@@ -86,7 +86,7 @@ var updateCmd = &cobra.Command{
 			}
 
 			fmt.Printf("%s: updating %s -> %s\n", name, s.Manifest.Version, entry.Version)
-			if err := inst.Install(name, true, false); err != nil {
+			if err := inst.Install(cmd.Context(), name, true, false); err != nil {
 				fmt.Printf("%s: update failed: %v\n", name, err)
 				continue
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,4 @@
+// Package config manages skillhub configuration loading and persistence.
 package config
 
 import (
@@ -8,6 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// RegistryEntry describes a single configured skill registry.
 type RegistryEntry struct {
 	Name         string `yaml:"name"`
 	URL          string `yaml:"url"`
@@ -17,6 +19,7 @@ type RegistryEntry struct {
 	SkillsPrefix string `yaml:"skills_prefix,omitempty"`
 }
 
+// Config holds the top-level skillhub configuration.
 type Config struct {
 	Registries []RegistryEntry `yaml:"registries"`
 	InstallDir string          `yaml:"install_dir"`
@@ -24,6 +27,7 @@ type Config struct {
 	LogDir     string          `yaml:"log_dir"`
 }
 
+// DefaultConfig returns a Config with default directory paths under home.
 func DefaultConfig(home string) *Config {
 	return &Config{
 		Registries: []RegistryEntry{},
@@ -33,6 +37,7 @@ func DefaultConfig(home string) *Config {
 	}
 }
 
+// Load reads and parses a YAML config file from the given path.
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -47,6 +52,7 @@ func Load(path string) (*Config, error) {
 	return &cfg, nil
 }
 
+// Save writes the config as YAML to the given path.
 func (c *Config) Save(path string) error {
 	data, err := yaml.Marshal(c)
 	if err != nil {
@@ -60,6 +66,7 @@ func (c *Config) Save(path string) error {
 	return nil
 }
 
+// Validate checks that all registries have required fields.
 func (c *Config) Validate() error {
 	for i, r := range c.Registries {
 		if r.Name == "" {
@@ -72,10 +79,11 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func (c *Config) AddRegistry(name, url, token, username, branch, skillsPrefix string) error {
+// AddRegistry adds or updates a registry entry by name.
+func (c *Config) AddRegistry(name, rawURL, token, username, branch, skillsPrefix string) error {
 	for i, r := range c.Registries {
 		if r.Name == name {
-			c.Registries[i].URL = url
+			c.Registries[i].URL = rawURL
 			c.Registries[i].Token = token
 			c.Registries[i].Username = username
 			c.Registries[i].Branch = branch
@@ -83,10 +91,11 @@ func (c *Config) AddRegistry(name, url, token, username, branch, skillsPrefix st
 			return nil
 		}
 	}
-	c.Registries = append(c.Registries, RegistryEntry{Name: name, URL: url, Token: token, Username: username, Branch: branch, SkillsPrefix: skillsPrefix})
+	c.Registries = append(c.Registries, RegistryEntry{Name: name, URL: rawURL, Token: token, Username: username, Branch: branch, SkillsPrefix: skillsPrefix})
 	return nil
 }
 
+// RemoveRegistry deletes the registry entry with the given name.
 func (c *Config) RemoveRegistry(name string) error {
 	for i, r := range c.Registries {
 		if r.Name == name {

--- a/internal/installer/extract.go
+++ b/internal/installer/extract.go
@@ -12,6 +12,7 @@ import (
 
 const maxFileSize = 100 * 1024 * 1024 // 100MB
 
+// ExtractTarGz extracts a gzip-compressed tar archive into destDir.
 func ExtractTarGz(archivePath string, destDir string) error {
 	f, err := os.Open(archivePath)
 	if err != nil {

--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -1,6 +1,8 @@
+// Package installer downloads, extracts, and verifies skill archives.
 package installer
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +14,7 @@ import (
 	"github.com/jayl2kor/skillhub/internal/storage"
 )
 
+// Installer downloads and installs skills from configured registries.
 type Installer struct {
 	Paths      *storage.Paths
 	Config     *config.Config
@@ -22,6 +25,7 @@ type Installer struct {
 	RepoFilter string // filter by registry name (empty = all)
 }
 
+// NewInstaller returns an Installer configured with the given paths and config.
 func NewInstaller(paths *storage.Paths, cfg *config.Config) *Installer {
 	return &Installer{
 		Paths:   paths,
@@ -37,7 +41,8 @@ func (inst *Installer) logVerbose(format string, args ...any) {
 	}
 }
 
-func (inst *Installer) Install(name string, force bool, global bool) error {
+// Install downloads and installs the named skill from a registry.
+func (inst *Installer) Install(ctx context.Context, name string, force bool, global bool) error {
 	// 1. Check if already installed
 	inst.logVerbose("checking if %q is already installed", name)
 	if !force && storage.IsInstalled(inst.Paths, name) {
@@ -71,7 +76,7 @@ func (inst *Installer) Install(name string, force bool, global bool) error {
 
 	// 3. Fetch and merge all indexes
 	inst.logVerbose("fetching indexes from %d registry(ies)", len(sources))
-	idx, err := inst.Client.FetchAllIndexes(sources)
+	idx, err := inst.Client.FetchAllIndexes(ctx, sources)
 	if err != nil {
 		return fmt.Errorf("fetching indexes: %w", err)
 	}
@@ -124,14 +129,14 @@ func (inst *Installer) Install(name string, force bool, global bool) error {
 		inst.Client.OnProgress = func(filename string) {
 			inst.logVerbose("  %s", filename)
 		}
-		if err := inst.Client.DownloadDirectory(matchedSource, entry.DownloadURL, tmpDir); err != nil {
+		if err := inst.Client.DownloadDirectory(ctx, matchedSource, entry.DownloadURL, tmpDir); err != nil {
 			return fmt.Errorf("downloading skill directory: %w", err)
 		}
 	} else {
 		// Archive mode: download tar.gz, verify, extract
 		cacheFile := filepath.Join(inst.Paths.CacheDir, fmt.Sprintf("%s-%s.tar.gz", name, entry.Version))
 		inst.logVerbose("downloading %s to %s", downloadURL, cacheFile)
-		if err := inst.Client.Download(downloadURL, cacheFile, token, username); err != nil {
+		if err := inst.Client.Download(ctx, downloadURL, cacheFile, token, username); err != nil {
 			return fmt.Errorf("downloading skill: %w", err)
 		}
 

--- a/internal/installer/install_test.go
+++ b/internal/installer/install_test.go
@@ -3,6 +3,7 @@ package installer
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -99,7 +100,7 @@ func TestInstall(t *testing.T) {
 
 	inst := NewInstaller(paths, cfg)
 
-	if err := inst.Install("test-skill", false, false); err != nil {
+	if err := inst.Install(context.Background(), "test-skill", false, false); err != nil {
 		t.Fatalf("Install: %v", err)
 	}
 
@@ -132,16 +133,16 @@ func TestInstallAlreadyInstalled(t *testing.T) {
 
 	inst := NewInstaller(paths, cfg)
 
-	if err := inst.Install("test-skill", false, false); err != nil {
+	if err := inst.Install(context.Background(), "test-skill", false, false); err != nil {
 		t.Fatalf("first Install: %v", err)
 	}
 
-	err := inst.Install("test-skill", false, false)
+	err := inst.Install(context.Background(), "test-skill", false, false)
 	if err == nil {
 		t.Error("expected error for already installed skill")
 	}
 
-	if err := inst.Install("test-skill", true, false); err != nil {
+	if err := inst.Install(context.Background(), "test-skill", true, false); err != nil {
 		t.Errorf("force Install: %v", err)
 	}
 }
@@ -165,7 +166,7 @@ func TestInstallNotFound(t *testing.T) {
 	}
 
 	inst := NewInstaller(paths, cfg)
-	err := inst.Install("nonexistent", false, false)
+	err := inst.Install(context.Background(), "nonexistent", false, false)
 	if err == nil {
 		t.Error("expected error for nonexistent skill")
 	}
@@ -233,7 +234,7 @@ func TestInstallDirectoryMode(t *testing.T) {
 
 	inst := NewInstaller(paths, cfg)
 
-	if err := inst.Install("dir-skill", false, false); err != nil {
+	if err := inst.Install(context.Background(), "dir-skill", false, false); err != nil {
 		t.Fatalf("Install directory mode: %v", err)
 	}
 
@@ -266,18 +267,18 @@ func TestInstallDirectoryModeForceReinstall(t *testing.T) {
 
 	inst := NewInstaller(paths, cfg)
 
-	if err := inst.Install("dir-skill", false, false); err != nil {
+	if err := inst.Install(context.Background(), "dir-skill", false, false); err != nil {
 		t.Fatalf("first Install: %v", err)
 	}
 
 	// Should fail without --force
-	err := inst.Install("dir-skill", false, false)
+	err := inst.Install(context.Background(), "dir-skill", false, false)
 	if err == nil {
 		t.Error("expected error for already installed skill")
 	}
 
 	// Should succeed with --force
-	if err := inst.Install("dir-skill", true, false); err != nil {
+	if err := inst.Install(context.Background(), "dir-skill", true, false); err != nil {
 		t.Errorf("force Install directory mode: %v", err)
 	}
 }
@@ -292,7 +293,7 @@ func TestInstallNoRegistries(t *testing.T) {
 	cfg := &config.Config{}
 
 	inst := NewInstaller(paths, cfg)
-	err := inst.Install("test", false, false)
+	err := inst.Install(context.Background(), "test", false, false)
 	if err == nil {
 		t.Error("expected error when no registries configured")
 	}

--- a/internal/installer/verify.go
+++ b/internal/installer/verify.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 )
 
+// VerifyChecksum checks that the SHA-256 of the file matches the expected value.
 func VerifyChecksum(filePath string, expected string) error {
 	if expected == "" {
 		return nil
@@ -27,6 +28,7 @@ func VerifyChecksum(filePath string, expected string) error {
 	return nil
 }
 
+// ComputeSHA256 returns the hex-encoded SHA-256 digest of the file.
 func ComputeSHA256(filePath string) (string, error) {
 	f, err := os.Open(filePath)
 	if err != nil {

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -73,7 +73,7 @@ func TestFullWorkflow(t *testing.T) {
 	// Step 3: Search
 	sources := []registry.RepoSource{{Name: "test-reg", URL: regDir}}
 	client := registry.NewClient()
-	fetchedIdx, err := client.FetchAllIndexes(sources)
+	fetchedIdx, err := client.FetchAllIndexes(context.Background(), sources)
 	if err != nil {
 		t.Fatalf("FetchAllIndexes: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestFullWorkflow(t *testing.T) {
 
 	// Step 4: Install
 	inst := installer.NewInstaller(paths, cfg)
-	if err := inst.Install("test-prompt", false, false); err != nil {
+	if err := inst.Install(context.Background(), "test-prompt", false, false); err != nil {
 		t.Fatalf("Install: %v", err)
 	}
 

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -1,6 +1,8 @@
+// Package registry handles communication with remote skill registries.
 package registry
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -19,11 +21,13 @@ const (
 	maxAPIResponseSize = 10 * 1024 * 1024  // 10MB for API/JSON responses
 )
 
+// Client communicates with remote skill registries.
 type Client struct {
 	HTTPClient *http.Client
 	OnProgress func(filename string) // called for each file downloaded in directory mode
 }
 
+// NewClient returns a Client with sensible default HTTP settings.
 func NewClient() *Client {
 	return &Client{
 		HTTPClient: &http.Client{
@@ -44,7 +48,7 @@ func NewClient() *Client {
 // DetectDefaultBranch queries the GitHub API to find the default branch.
 // For non-github.com hosts, it uses the /api/v3/ endpoint.
 // Returns "main" as fallback if detection fails.
-func (c *Client) DetectDefaultBranch(source *RepoSource) string {
+func (c *Client) DetectDefaultBranch(ctx context.Context, source *RepoSource) string {
 	if isLocalPath(source.URL) {
 		return "main"
 	}
@@ -62,7 +66,7 @@ func (c *Client) DetectDefaultBranch(source *RepoSource) string {
 		apiURL = fmt.Sprintf("%s://%s/api/v3/repos/%s", u.Scheme, u.Host, ownerRepo)
 	}
 
-	data, err := c.fetch(apiURL, source.Token, source.Username)
+	data, err := c.fetch(ctx, apiURL, source.Token, source.Username)
 	if err != nil {
 		return "main"
 	}
@@ -76,10 +80,11 @@ func (c *Client) DetectDefaultBranch(source *RepoSource) string {
 	return repo.DefaultBranch
 }
 
-func (c *Client) FetchIndex(source *RepoSource) (*Index, error) {
+// FetchIndex downloads and parses the index from a single registry source.
+func (c *Client) FetchIndex(ctx context.Context, source *RepoSource) (*Index, error) {
 	indexURL := source.IndexURL()
 
-	data, err := c.fetch(indexURL, source.Token, source.Username)
+	data, err := c.fetch(ctx, indexURL, source.Token, source.Username)
 	if err != nil {
 		return nil, fmt.Errorf("fetching index from %s: %w", source.Name, err)
 	}
@@ -96,12 +101,12 @@ func (c *Client) FetchIndex(source *RepoSource) (*Index, error) {
 	return idx, nil
 }
 
-func (c *Client) FetchAllIndexes(sources []RepoSource) (*Index, error) {
+// FetchAllIndexes fetches indexes from all sources and merges them.
+func (c *Client) FetchAllIndexes(ctx context.Context, sources []RepoSource) (*Index, error) {
 	var indexes []*Index
 
 	for _, src := range sources {
-		src := src
-		idx, err := c.FetchIndex(&src)
+		idx, err := c.FetchIndex(ctx, &src)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to fetch from %s: %v\n", src.Name, err)
 			continue
@@ -112,7 +117,8 @@ func (c *Client) FetchAllIndexes(sources []RepoSource) (*Index, error) {
 	return MergeIndexes(indexes...), nil
 }
 
-func (c *Client) Download(rawURL, dest, token, username string) error {
+// Download fetches a file from rawURL and writes it to dest.
+func (c *Client) Download(ctx context.Context, rawURL, dest, token, username string) error {
 	if isLocalPath(rawURL) {
 		data, err := os.ReadFile(rawURL)
 		if err != nil {
@@ -121,7 +127,7 @@ func (c *Client) Download(rawURL, dest, token, username string) error {
 		return os.WriteFile(dest, data, 0644)
 	}
 
-	req, err := c.newRequest(rawURL, token, username)
+	req, err := c.newRequest(ctx, rawURL, token, username)
 	if err != nil {
 		return fmt.Errorf("creating request for %s: %w", rawURL, err)
 	}
@@ -169,7 +175,7 @@ type githubContentEntry struct {
 // DownloadDirectory downloads all files from a directory source into destDir.
 // For local paths, it copies the directory tree. For GitHub, it uses the Contents API.
 // If OnProgress is set, it is called with each file's relative name after download.
-func (c *Client) DownloadDirectory(source *RepoSource, dirPath, destDir string) error {
+func (c *Client) DownloadDirectory(ctx context.Context, source *RepoSource, dirPath, destDir string) error {
 	dirPath = strings.TrimSuffix(dirPath, "/")
 
 	if isLocalPath(source.URL) {
@@ -177,7 +183,7 @@ func (c *Client) DownloadDirectory(source *RepoSource, dirPath, destDir string) 
 		return c.copyDirectory(srcDir, destDir)
 	}
 
-	return c.downloadGitHubDirectory(source, dirPath, destDir)
+	return c.downloadGitHubDirectory(ctx, source, dirPath, destDir)
 }
 
 func (c *Client) copyDirectory(srcDir, destDir string) error {
@@ -223,10 +229,10 @@ func (c *Client) copyDirectory(srcDir, destDir string) error {
 // maxConcurrentDownloads limits the number of concurrent file downloads.
 const maxConcurrentDownloads = 8
 
-func (c *Client) downloadGitHubDirectory(source *RepoSource, dirPath, destDir string) error {
+func (c *Client) downloadGitHubDirectory(ctx context.Context, source *RepoSource, dirPath, destDir string) error {
 	apiURL := source.ContentsAPIURL(dirPath)
 
-	data, err := c.fetch(apiURL, source.Token, source.Username)
+	data, err := c.fetch(ctx, apiURL, source.Token, source.Username)
 	if err != nil {
 		return fmt.Errorf("listing directory %s: %w", dirPath, err)
 	}
@@ -253,7 +259,7 @@ func (c *Client) downloadGitHubDirectory(source *RepoSource, dirPath, destDir st
 		if err := os.MkdirAll(destPath, 0755); err != nil {
 			return fmt.Errorf("creating directory %s: %w", destPath, err)
 		}
-		if err := c.downloadGitHubDirectory(source, entry.Path, destPath); err != nil {
+		if err := c.downloadGitHubDirectory(ctx, source, entry.Path, destPath); err != nil {
 			return err
 		}
 	}
@@ -280,7 +286,7 @@ func (c *Client) downloadGitHubDirectory(source *RepoSource, dirPath, destDir st
 
 			destPath := filepath.Join(destDir, entry.Name)
 			downloadURL := source.ResolveDownloadURL(entry.Path)
-			if err := c.Download(downloadURL, destPath, source.Token, source.Username); err != nil {
+			if err := c.Download(ctx, downloadURL, destPath, source.Token, source.Username); err != nil {
 				mu.Lock()
 				if firstErr == nil {
 					firstErr = fmt.Errorf("downloading %s: %w", entry.Name, err)
@@ -298,8 +304,8 @@ func (c *Client) downloadGitHubDirectory(source *RepoSource, dirPath, destDir st
 	return firstErr
 }
 
-func (c *Client) newRequest(rawURL, token, username string) (*http.Request, error) {
-	req, err := http.NewRequest("GET", rawURL, nil)
+func (c *Client) newRequest(ctx context.Context, rawURL, token, username string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", rawURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -353,12 +359,12 @@ func checkResponse(resp *http.Response, rawURL, token string) error {
 	return nil
 }
 
-func (c *Client) fetch(rawURL, token, username string) ([]byte, error) {
+func (c *Client) fetch(ctx context.Context, rawURL, token, username string) ([]byte, error) {
 	if isLocalPath(rawURL) {
 		return os.ReadFile(rawURL)
 	}
 
-	req, err := c.newRequest(rawURL, token, username)
+	req, err := c.newRequest(ctx, rawURL, token, username)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/registry/client_test.go
+++ b/internal/registry/client_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -23,7 +24,7 @@ func TestFetchIndexLocal(t *testing.T) {
 	client := NewClient()
 	source := &RepoSource{Name: "local", URL: dir}
 
-	idx, err := client.FetchIndex(source)
+	idx, err := client.FetchIndex(context.Background(), source)
 	if err != nil {
 		t.Fatalf("FetchIndex: %v", err)
 	}
@@ -53,7 +54,7 @@ func TestFetchIndexHTTP(t *testing.T) {
 	client := NewClient()
 
 	// Direct fetch test
-	data, err := client.fetch(server.URL, "", "")
+	data, err := client.fetch(context.Background(), server.URL, "", "")
 	if err != nil {
 		t.Fatalf("fetch: %v", err)
 	}
@@ -87,7 +88,7 @@ func TestFetchAllIndexes(t *testing.T) {
 		{Name: "reg2", URL: dir2},
 	}
 
-	idx, err := client.FetchAllIndexes(sources)
+	idx, err := client.FetchAllIndexes(context.Background(), sources)
 	if err != nil {
 		t.Fatalf("FetchAllIndexes: %v", err)
 	}
@@ -109,7 +110,7 @@ func TestDownload(t *testing.T) {
 	dest := filepath.Join(dir, "downloaded")
 
 	client := NewClient()
-	if err := client.Download(server.URL, dest, "", ""); err != nil {
+	if err := client.Download(context.Background(), server.URL, dest, "", ""); err != nil {
 		t.Fatalf("Download: %v", err)
 	}
 
@@ -140,7 +141,7 @@ func TestDownloadExceedsMaxSize(t *testing.T) {
 	dest := filepath.Join(dir, "downloaded")
 
 	client := NewClient()
-	if err := client.Download(server.URL, dest, "", ""); err != nil {
+	if err := client.Download(context.Background(), server.URL, dest, "", ""); err != nil {
 		t.Fatalf("Download should succeed for small content: %v", err)
 	}
 }
@@ -160,7 +161,7 @@ func TestFetchExceedsMaxAPIResponseSize(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient()
-	_, err := client.fetch(server.URL, "", "")
+	_, err := client.fetch(context.Background(), server.URL, "", "")
 	if err == nil {
 		t.Fatal("expected error for oversized API response")
 	}
@@ -175,7 +176,7 @@ func TestDownloadLocal(t *testing.T) {
 
 	dest := filepath.Join(dir, "dest.tar.gz")
 	client := NewClient()
-	if err := client.Download(srcFile, dest, "", ""); err != nil {
+	if err := client.Download(context.Background(), srcFile, dest, "", ""); err != nil {
 		t.Fatalf("local Download: %v", err)
 	}
 
@@ -256,7 +257,7 @@ func TestDownloadDirectoryLocal(t *testing.T) {
 	client := NewClient()
 	source := &RepoSource{Name: "local", URL: srcDir}
 
-	if err := client.DownloadDirectory(source, "skills/my-skill/", destDir); err != nil {
+	if err := client.DownloadDirectory(context.Background(), source, "skills/my-skill/", destDir); err != nil {
 		t.Fatalf("DownloadDirectory: %v", err)
 	}
 
@@ -313,7 +314,7 @@ func TestDownloadDirectoryLocalSkipsHiddenFiles(t *testing.T) {
 	client := NewClient()
 	source := &RepoSource{Name: "local", URL: srcDir}
 
-	if err := client.DownloadDirectory(source, "skills/my-skill/", destDir); err != nil {
+	if err := client.DownloadDirectory(context.Background(), source, "skills/my-skill/", destDir); err != nil {
 		t.Fatalf("DownloadDirectory: %v", err)
 	}
 
@@ -367,7 +368,7 @@ func TestDownloadDirectoryGitHub(t *testing.T) {
 
 	destDir := t.TempDir()
 	client := NewClient()
-	if err := client.DownloadDirectory(source, "skills/test-skill/", destDir); err != nil {
+	if err := client.DownloadDirectory(context.Background(), source, "skills/test-skill/", destDir); err != nil {
 		t.Fatalf("DownloadDirectory GitHub: %v", err)
 	}
 
@@ -428,7 +429,7 @@ func TestDownloadDirectoryGitHubConcurrent(t *testing.T) {
 
 	destDir := t.TempDir()
 	client := NewClient()
-	if err := client.DownloadDirectory(source, "skills/many-files/", destDir); err != nil {
+	if err := client.DownloadDirectory(context.Background(), source, "skills/many-files/", destDir); err != nil {
 		t.Fatalf("DownloadDirectory: %v", err)
 	}
 

--- a/internal/registry/index.go
+++ b/internal/registry/index.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 )
 
+// IndexEntry describes a single skill in a registry index.
 type IndexEntry struct {
 	Name        string   `json:"name"`
 	Version     string   `json:"version"`
@@ -16,10 +17,12 @@ type IndexEntry struct {
 	Registry    string   `json:"-"`
 }
 
+// Index holds the full list of skills available in a registry.
 type Index struct {
 	Skills []IndexEntry `json:"skills"`
 }
 
+// ParseIndex unmarshals JSON data into an Index.
 func ParseIndex(data []byte) (*Index, error) {
 	var idx Index
 	if err := json.Unmarshal(data, &idx); err != nil {
@@ -28,6 +31,7 @@ func ParseIndex(data []byte) (*Index, error) {
 	return &idx, nil
 }
 
+// Search returns entries whose name, description, or tags match the query.
 func (idx *Index) Search(query string) []IndexEntry {
 	if query == "*" || query == "" {
 		return idx.Skills
@@ -60,6 +64,7 @@ func matchesQuery(entry IndexEntry, query string) bool {
 	return false
 }
 
+// Find returns the first entry with the given name, or nil if not found.
 func (idx *Index) Find(name string) *IndexEntry {
 	for _, entry := range idx.Skills {
 		if entry.Name == name {
@@ -79,6 +84,7 @@ func (idx *Index) FindVersion(name, version string) *IndexEntry {
 	return nil
 }
 
+// MergeIndexes combines multiple indexes into a single unified index.
 func MergeIndexes(indexes ...*Index) *Index {
 	merged := &Index{}
 	for _, idx := range indexes {

--- a/internal/registry/repo.go
+++ b/internal/registry/repo.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+// RepoSource describes a skill registry backed by a Git repository.
 type RepoSource struct {
 	Name     string
 	URL      string
@@ -22,6 +23,7 @@ func (r *RepoSource) branch() string {
 	return "main"
 }
 
+// IndexURL returns the URL for the registry's index.json file.
 func (r *RepoSource) IndexURL() string {
 	if isLocalPath(r.URL) {
 		return filepath.Join(r.URL, "index.json")
@@ -29,6 +31,7 @@ func (r *RepoSource) IndexURL() string {
 	return rawContentURL(r.URL, "index.json", r.branch())
 }
 
+// ResolveDownloadURL converts a relative path to a full download URL.
 func (r *RepoSource) ResolveDownloadURL(relative string) string {
 	if strings.HasPrefix(relative, "http://") || strings.HasPrefix(relative, "https://") {
 		return relative
@@ -39,6 +42,7 @@ func (r *RepoSource) ResolveDownloadURL(relative string) string {
 	return rawContentURL(r.URL, relative, r.branch())
 }
 
+// ParseRepoURL parses a repository URL or shorthand into a RepoSource.
 func ParseRepoURL(rawURL string) (*RepoSource, error) {
 	raw := strings.TrimSpace(rawURL)
 

--- a/internal/registry/upload.go
+++ b/internal/registry/upload.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -24,14 +25,14 @@ type githubFileInfo struct {
 
 // GetFileSHA returns the blob SHA of a file in a GitHub repository.
 // Returns "" if the file does not exist (404).
-func (c *Client) GetFileSHA(source *RepoSource, path string) (string, error) {
+func (c *Client) GetFileSHA(ctx context.Context, source *RepoSource, path string) (string, error) {
 	if source.IsLocal() {
 		return "", nil
 	}
 
 	apiURL := source.ContentsAPIPutURL(path) + "?ref=" + source.branch()
 
-	req, err := c.newRequest(apiURL, source.Token, source.Username)
+	req, err := c.newRequest(ctx, apiURL, source.Token, source.Username)
 	if err != nil {
 		return "", fmt.Errorf("creating request: %w", err)
 	}
@@ -64,7 +65,7 @@ func (c *Client) GetFileSHA(source *RepoSource, path string) (string, error) {
 
 // UploadFile uploads content to a registry. For local registries it writes
 // directly to the filesystem. For GitHub it uses the Contents API.
-func (c *Client) UploadFile(source *RepoSource, path string, content []byte, sha, message string) error {
+func (c *Client) UploadFile(ctx context.Context, source *RepoSource, path string, content []byte, sha, message string) error {
 	if source.IsLocal() {
 		dest := filepath.Join(source.URL, path)
 		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
@@ -87,7 +88,7 @@ func (c *Client) UploadFile(source *RepoSource, path string, content []byte, sha
 		return fmt.Errorf("marshaling request: %w", err)
 	}
 
-	req, err := http.NewRequest("PUT", apiURL, bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, "PUT", apiURL, bytes.NewReader(jsonBody))
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
 	}
@@ -120,7 +121,7 @@ func (c *Client) UploadFile(source *RepoSource, path string, content []byte, sha
 // UploadDirectory uploads all files from srcDir to destPrefix in the registry.
 // For local registries it copies the directory tree. For GitHub it uploads
 // each file via the Contents API. Hidden files/directories are skipped.
-func (c *Client) UploadDirectory(source *RepoSource, srcDir, destPrefix, message string) error {
+func (c *Client) UploadDirectory(ctx context.Context, source *RepoSource, srcDir, destPrefix, message string) error {
 	if source.IsLocal() {
 		destDir := filepath.Join(source.URL, destPrefix)
 		if err := os.MkdirAll(destDir, 0755); err != nil {
@@ -178,12 +179,12 @@ func (c *Client) UploadDirectory(source *RepoSource, srcDir, destPrefix, message
 			return fmt.Errorf("reading %s: %w", rel, err)
 		}
 
-		sha, err := c.GetFileSHA(source, remotePath)
+		sha, err := c.GetFileSHA(ctx, source, remotePath)
 		if err != nil {
 			return fmt.Errorf("checking %s: %w", remotePath, err)
 		}
 
-		if err := c.UploadFile(source, remotePath, content, sha, message); err != nil {
+		if err := c.UploadFile(ctx, source, remotePath, content, sha, message); err != nil {
 			return fmt.Errorf("uploading %s: %w", rel, err)
 		}
 
@@ -197,7 +198,7 @@ func (c *Client) UploadDirectory(source *RepoSource, srcDir, destPrefix, message
 // UpdateIndex fetches the current index.json from the registry, upserts the
 // given entry, and writes it back. If force is false and a matching
 // name+version already exists, it returns an error.
-func (c *Client) UpdateIndex(source *RepoSource, entry IndexEntry, force bool) error {
+func (c *Client) UpdateIndex(ctx context.Context, source *RepoSource, entry IndexEntry, force bool) error {
 	idx := &Index{}
 
 	if source.IsLocal() {
@@ -210,7 +211,7 @@ func (c *Client) UpdateIndex(source *RepoSource, entry IndexEntry, force bool) e
 			}
 		}
 	} else {
-		data, err := c.fetch(source.IndexURL(), source.Token, source.Username)
+		data, err := c.fetch(ctx, source.IndexURL(), source.Token, source.Username)
 		if err == nil {
 			parsed, parseErr := ParseIndex(data)
 			if parseErr == nil {
@@ -247,11 +248,11 @@ func (c *Client) UpdateIndex(source *RepoSource, entry IndexEntry, force bool) e
 		return os.WriteFile(filepath.Join(source.URL, "index.json"), indexData, 0644)
 	}
 
-	sha, err := c.GetFileSHA(source, "index.json")
+	sha, err := c.GetFileSHA(ctx, source, "index.json")
 	if err != nil {
 		return fmt.Errorf("getting index.json SHA: %w", err)
 	}
 
 	msg := fmt.Sprintf("update index: %s@%s", entry.Name, entry.Version)
-	return c.UploadFile(source, "index.json", indexData, sha, msg)
+	return c.UploadFile(ctx, source, "index.json", indexData, sha, msg)
 }

--- a/internal/registry/upload_test.go
+++ b/internal/registry/upload_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -89,7 +90,7 @@ func TestGetFileSHA(t *testing.T) {
 		Branch: "main",
 	}
 
-	sha, err := client.GetFileSHA(source, "skills/my-skill/skill.json")
+	sha, err := client.GetFileSHA(context.Background(), source, "skills/my-skill/skill.json")
 	if err != nil {
 		t.Fatalf("GetFileSHA existing: %v", err)
 	}
@@ -97,7 +98,7 @@ func TestGetFileSHA(t *testing.T) {
 		t.Errorf("expected sha abc123, got %q", sha)
 	}
 
-	sha, err = client.GetFileSHA(source, "skills/my-skill/missing.md")
+	sha, err = client.GetFileSHA(context.Background(), source, "skills/my-skill/missing.md")
 	if err != nil {
 		t.Fatalf("GetFileSHA missing: %v", err)
 	}
@@ -137,7 +138,7 @@ func TestUploadFileGitHub(t *testing.T) {
 	}
 
 	content := []byte(`{"name":"my-skill"}`)
-	err := client.UploadFile(source, "skills/my-skill/skill.json", content, "", "publish my-skill@1.0.0")
+	err := client.UploadFile(context.Background(), source, "skills/my-skill/skill.json", content, "", "publish my-skill@1.0.0")
 	if err != nil {
 		t.Fatalf("UploadFile: %v", err)
 	}
@@ -163,7 +164,7 @@ func TestUploadFileLocal(t *testing.T) {
 	source := &RepoSource{URL: dir}
 
 	content := []byte(`{"name":"my-skill"}`)
-	err := client.UploadFile(source, "skills/my-skill/skill.json", content, "", "")
+	err := client.UploadFile(context.Background(), source, "skills/my-skill/skill.json", content, "", "")
 	if err != nil {
 		t.Fatalf("UploadFile local: %v", err)
 	}
@@ -201,7 +202,7 @@ func TestUploadDirectoryLocal(t *testing.T) {
 	client := NewClient()
 	source := &RepoSource{Name: "local", URL: regDir}
 
-	if err := client.UploadDirectory(source, srcDir, "skills/test", "publish"); err != nil {
+	if err := client.UploadDirectory(context.Background(), source, srcDir, "skills/test", "publish"); err != nil {
 		t.Fatalf("UploadDirectory: %v", err)
 	}
 
@@ -267,7 +268,7 @@ func TestUploadDirectoryGitHub(t *testing.T) {
 		Token:  "tok",
 	}
 
-	if err := client.UploadDirectory(source, srcDir, "skills/test", "publish test@1.0.0"); err != nil {
+	if err := client.UploadDirectory(context.Background(), source, srcDir, "skills/test", "publish test@1.0.0"); err != nil {
 		t.Fatalf("UploadDirectory GitHub: %v", err)
 	}
 
@@ -297,7 +298,7 @@ func TestUpdateIndexLocal(t *testing.T) {
 	}
 
 	// First publish: creates index.json
-	if err := client.UpdateIndex(source, entry, false); err != nil {
+	if err := client.UpdateIndex(context.Background(), source, entry, false); err != nil {
 		t.Fatalf("UpdateIndex create: %v", err)
 	}
 
@@ -317,14 +318,14 @@ func TestUpdateIndexLocal(t *testing.T) {
 	}
 
 	// Duplicate without force: should error
-	err = client.UpdateIndex(source, entry, false)
+	err = client.UpdateIndex(context.Background(), source, entry, false)
 	if err == nil {
 		t.Fatal("expected error for duplicate version without force")
 	}
 
 	// Duplicate with force: should succeed
 	entry.Description = "updated skill"
-	if err := client.UpdateIndex(source, entry, true); err != nil {
+	if err := client.UpdateIndex(context.Background(), source, entry, true); err != nil {
 		t.Fatalf("UpdateIndex force: %v", err)
 	}
 
@@ -350,7 +351,7 @@ func TestUpdateIndexLocal(t *testing.T) {
 		Description: "v2",
 		DownloadURL: "skills/my-skill/",
 	}
-	if err := client.UpdateIndex(source, entry2, false); err != nil {
+	if err := client.UpdateIndex(context.Background(), source, entry2, false); err != nil {
 		t.Fatalf("UpdateIndex new version: %v", err)
 	}
 

--- a/internal/runtime/exec.go
+++ b/internal/runtime/exec.go
@@ -17,6 +17,7 @@ type ExecRunner struct {
 	Args    []string // extra args before the script path
 }
 
+// Run executes the skill's entry file using the configured interpreter.
 func (r *ExecRunner) Run(ctx context.Context, s skill.InstalledSkill, args []string) error {
 	entry := s.Manifest.Entry
 

--- a/internal/runtime/prompt.go
+++ b/internal/runtime/prompt.go
@@ -10,8 +10,10 @@ import (
 	"github.com/jayl2kor/skillhub/internal/skill"
 )
 
+// PromptRunner runs prompt-type skills by printing the entry file contents.
 type PromptRunner struct{}
 
+// Run outputs the content of the skill's entry file to stdout.
 func (r *PromptRunner) Run(_ context.Context, s skill.InstalledSkill, _ []string) error {
 	entry := s.Manifest.Entry
 

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -1,3 +1,4 @@
+// Package runtime provides runners that execute installed skills.
 package runtime
 
 import (
@@ -7,10 +8,12 @@ import (
 	"github.com/jayl2kor/skillhub/internal/skill"
 )
 
+// SkillRunner executes an installed skill with the given arguments.
 type SkillRunner interface {
 	Run(ctx context.Context, s skill.InstalledSkill, args []string) error
 }
 
+// RunnerFor returns the appropriate SkillRunner for the given skill type.
 func RunnerFor(skillType string) (SkillRunner, error) {
 	switch skillType {
 	case "prompt":

--- a/internal/skill/installed.go
+++ b/internal/skill/installed.go
@@ -7,12 +7,14 @@ import (
 	"time"
 )
 
+// InstalledSkill represents a skill that has been installed locally.
 type InstalledSkill struct {
 	Manifest Manifest
 	Dir      string
 	Meta     InstallMeta
 }
 
+// InstallMeta holds metadata about how and when a skill was installed.
 type InstallMeta struct {
 	InstalledAt string `json:"installed_at"`
 	Registry    string `json:"registry"`
@@ -20,6 +22,7 @@ type InstallMeta struct {
 	Checksum    string `json:"checksum,omitempty"`
 }
 
+// NewInstallMeta creates an InstallMeta with the current timestamp.
 func NewInstallMeta(registry, version, checksum string) InstallMeta {
 	return InstallMeta{
 		InstalledAt: time.Now().UTC().Format(time.RFC3339),
@@ -29,6 +32,7 @@ func NewInstallMeta(registry, version, checksum string) InstallMeta {
 	}
 }
 
+// LoadInstallMeta reads and parses install metadata from the given file path.
 func LoadInstallMeta(path string) (*InstallMeta, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -43,6 +47,7 @@ func LoadInstallMeta(path string) (*InstallMeta, error) {
 	return &meta, nil
 }
 
+// Save writes the install metadata to the given file path as JSON.
 func (m *InstallMeta) Save(path string) error {
 	data, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {

--- a/internal/skill/manifest.go
+++ b/internal/skill/manifest.go
@@ -1,3 +1,4 @@
+// Package skill defines skill manifests, versioning, and installation metadata.
 package skill
 
 import (
@@ -20,6 +21,7 @@ var (
 	}
 )
 
+// Manifest describes a skill's metadata as declared in skill.json.
 type Manifest struct {
 	Name             string   `json:"name"`
 	Version          string   `json:"version"`
@@ -33,6 +35,7 @@ type Manifest struct {
 	CompatibleAgents []string `json:"compatible_agents,omitempty"`
 }
 
+// LoadManifest reads and parses a skill manifest from the given file path.
 func LoadManifest(path string) (*Manifest, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -47,6 +50,7 @@ func LoadManifest(path string) (*Manifest, error) {
 	return &m, nil
 }
 
+// Validate checks that all required manifest fields are present and well-formed.
 func (m *Manifest) Validate() error {
 	if m.Name == "" {
 		return fmt.Errorf("manifest: name is required")

--- a/internal/skill/version.go
+++ b/internal/skill/version.go
@@ -6,16 +6,19 @@ import (
 	"strings"
 )
 
+// SemVer represents a semantic version with major, minor, and patch components.
 type SemVer struct {
 	Major int
 	Minor int
 	Patch int
 }
 
+// String returns the semver string representation "Major.Minor.Patch".
 func (v SemVer) String() string {
 	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
 }
 
+// ParseVersion parses a "X.Y.Z" version string into a SemVer.
 func ParseVersion(s string) (SemVer, error) {
 	parts := strings.Split(s, ".")
 	if len(parts) != 3 {

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -16,7 +16,10 @@ func DetectProjectRoot() string {
 	if err == nil {
 		return strings.TrimSpace(string(out))
 	}
-	cwd, _ := os.Getwd()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
 	return cwd
 }
 
@@ -27,6 +30,7 @@ func (p *Paths) projectRoot() string {
 	return DetectProjectRoot()
 }
 
+// ListInstalledSkills returns all skills installed globally and in the local project.
 func ListInstalledSkills(paths *Paths) ([]skill.InstalledSkill, error) {
 	seen := make(map[string]bool)
 	var skills []skill.InstalledSkill
@@ -71,6 +75,7 @@ func ListInstalledSkills(paths *Paths) ([]skill.InstalledSkill, error) {
 	return skills, nil
 }
 
+// IsInstalled reports whether a skill with the given name is installed.
 func IsInstalled(paths *Paths, name string) bool {
 	// Global check
 	manifestPath := filepath.Join(paths.SkillsDir, name, "skill.json")
@@ -88,6 +93,7 @@ func IsInstalled(paths *Paths, name string) bool {
 	return false
 }
 
+// GetInstalledSkill returns the installed skill with the given name, or an error if not found.
 func GetInstalledSkill(paths *Paths, name string) (*skill.InstalledSkill, error) {
 	// Check global path first
 	skillDir := filepath.Join(paths.SkillsDir, name)

--- a/internal/storage/paths.go
+++ b/internal/storage/paths.go
@@ -1,3 +1,4 @@
+// Package storage manages local skill directories and path resolution.
 package storage
 
 import (
@@ -6,6 +7,7 @@ import (
 	"path/filepath"
 )
 
+// Paths holds the directory layout for skillhub's storage.
 type Paths struct {
 	Home        string
 	Config      string
@@ -16,6 +18,7 @@ type Paths struct {
 	ProjectRoot string // project root for local skill lookup; empty means auto-detect
 }
 
+// NewPaths returns a Paths rooted at the given home directory.
 func NewPaths(home string) *Paths {
 	return &Paths{
 		Home:      home,
@@ -27,6 +30,7 @@ func NewPaths(home string) *Paths {
 	}
 }
 
+// DefaultHome returns the default skillhub home directory path.
 func DefaultHome() string {
 	if env := os.Getenv("SKILLHUB_HOME"); env != "" {
 		return env
@@ -40,6 +44,7 @@ func DefaultHome() string {
 	return filepath.Join(home, ".skillhub")
 }
 
+// EnsureDirectories creates all storage directories if they do not exist.
 func (p *Paths) EnsureDirectories() error {
 	dirs := []string{p.Home, p.SkillsDir, p.CacheDir, p.LogDir, p.TmpDir}
 	for _, dir := range dirs {
@@ -50,6 +55,7 @@ func (p *Paths) EnsureDirectories() error {
 	return nil
 }
 
+// SkillDir returns the directory path for the named skill.
 func (p *Paths) SkillDir(name string) string {
 	return filepath.Join(p.SkillsDir, name)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,4 @@
+// Package version exposes the build version of skillhub.
 package version
 
 var (


### PR DESCRIPTION
## Summary

- Add doc comments to all exported declarations (Closes #101)
- Flatten nested error handling with indent error flow / early returns (Closes #102)
- Handle deferred Close errors using named return values (Closes #103)
- Add package-level doc comments to all packages (Closes #104)
- Thread `context.Context` as first parameter through all public APIs (Closes #105, Closes #106)
- Rename shadowed `url` parameter to `rawURL` in `AddRegistry` (Closes #107)
- Remove unnecessary loop variable captures (Go 1.22+) (Closes #108)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all 8 packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)