### PR TITLE
refactor(go): apply Go Code Review Comments conventions

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -61,7 +61,9 @@ var doctorCmd = &cobra.Command{
 			fmt.Printf("NO (%v)\n", err)
 			ok = false
 		} else {
-			os.Remove(testFile)
+			if err := os.Remove(testFile); err != nil {
+				fmt.Printf("WARNING: could not clean up test file: %v\n", err)
+			}
 			fmt.Println("OK")
 		}
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -89,9 +89,11 @@ var doctorCmd = &cobra.Command{
 		// Check registries
 		fmt.Print("Registries... ")
 		cfg, err := config.Load(paths.Config)
-		if err == nil && len(cfg.Registries) > 0 {
+		if err != nil {
+			fmt.Println("SKIPPED (config load error)")
+		} else if len(cfg.Registries) > 0 {
 			fmt.Printf("%d configured\n", len(cfg.Registries))
-		} else if err == nil {
+		} else {
 			fmt.Println("none configured")
 		}
 

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -66,7 +66,8 @@ var infoCmd = &cobra.Command{
 		}
 
 		client := registry.NewClient()
-		idx, err := client.FetchAllIndexes(sources)
+		ctx := cmd.Context()
+		idx, err := client.FetchAllIndexes(ctx, sources)
 		if err != nil {
 			return fmt.Errorf("fetching indexes: %w", err)
 		}

--- a/internal/cli/info.go
+++ b/internal/cli/info.go
@@ -48,7 +48,7 @@ var infoCmd = &cobra.Command{
 		}
 
 		// Try from registry
-		cfg, err := loadOrSetupConfig()
+		cfg, err := loadOrSetupConfig(cmd.Context())
 		if err != nil {
 			return err
 		}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -19,7 +19,7 @@ var installCmd = &cobra.Command{
 	Short: "Install a skill",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := loadOrSetupConfig()
+		cfg, err := loadOrSetupConfig(cmd.Context())
 		if err != nil {
 			return err
 		}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -29,7 +29,7 @@ var installCmd = &cobra.Command{
 		inst.AgentTool = installTool
 		inst.Version = installVersion
 		inst.RepoFilter = installRepo
-		return inst.Install(args[0], forceInstall, globalInstall)
+		return inst.Install(cmd.Context(), args[0], forceInstall, globalInstall)
 	},
 }
 

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -17,7 +17,11 @@ func printFormatted(data any) error {
 		enc.SetIndent("", "  ")
 		return enc.Encode(data)
 	case "yaml":
-		return yaml.NewEncoder(os.Stdout).Encode(data)
+		enc := yaml.NewEncoder(os.Stdout)
+		if err := enc.Encode(data); err != nil {
+			return err
+		}
+		return enc.Close()
 	default:
 		return fmt.Errorf("unsupported output format %q", outputFormat)
 	}

--- a/internal/cli/package.go
+++ b/internal/cli/package.go
@@ -84,18 +84,30 @@ func init() {
 	rootCmd.AddCommand(packageCmd)
 }
 
-func createTarGz(srcDir, destPath, prefix string) error {
+func createTarGz(srcDir, destPath, prefix string) (err error) {
 	outFile, err := os.Create(destPath)
 	if err != nil {
 		return fmt.Errorf("creating output file: %w", err)
 	}
-	defer outFile.Close()
+	defer func() {
+		if cerr := outFile.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing output file: %w", cerr)
+		}
+	}()
 
 	gw := gzip.NewWriter(outFile)
-	defer gw.Close()
+	defer func() {
+		if cerr := gw.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing gzip writer: %w", cerr)
+		}
+	}()
 
 	tw := tar.NewWriter(gw)
-	defer tw.Close()
+	defer func() {
+		if cerr := tw.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing tar writer: %w", cerr)
+		}
+	}()
 
 	srcDir, err = filepath.Abs(srcDir)
 	if err != nil {

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -125,6 +125,7 @@ var publishCmd = &cobra.Command{
 		}
 
 		client := registry.NewClient()
+		ctx := cmd.Context()
 
 		if !reg.IsLocal() && reg.Token == "" && reg.Username == "" {
 			return fmt.Errorf("registry %q has no credentials for write access; use --token <PAT> or configure via 'skillhub repo add <url> --token <PAT>'", reg.Name)
@@ -132,7 +133,7 @@ var publishCmd = &cobra.Command{
 
 		// Check version conflict via index
 		if !publishForce {
-			idx, err := client.FetchIndex(reg)
+			idx, err := client.FetchIndex(ctx, reg)
 			if err == nil {
 				if existing := idx.FindVersion(m.Name, m.Version); existing != nil {
 					return fmt.Errorf("version %s@%s already exists in %s (use --force to overwrite)", m.Name, m.Version, reg.Name)
@@ -148,7 +149,7 @@ var publishCmd = &cobra.Command{
 			}
 		}
 
-		if err := client.UploadDirectory(reg, dir, destPrefix, commitMsg); err != nil {
+		if err := client.UploadDirectory(ctx, reg, dir, destPrefix, commitMsg); err != nil {
 			return fmt.Errorf("uploading skill directory: %w", err)
 		}
 
@@ -160,7 +161,7 @@ var publishCmd = &cobra.Command{
 			Tags:        m.Tags,
 			DownloadURL: destPrefix + "/",
 		}
-		if err := client.UpdateIndex(reg, entry, publishForce); err != nil {
+		if err := client.UpdateIndex(ctx, reg, entry, publishForce); err != nil {
 			return fmt.Errorf("updating index: %w", err)
 		}
 

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -62,7 +62,7 @@ var publishCmd = &cobra.Command{
 		}
 
 		// Load config and resolve registry
-		cfg, err := loadOrSetupConfig()
+		cfg, err := loadOrSetupConfig(cmd.Context())
 		if err != nil {
 			return err
 		}

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -40,7 +40,8 @@ var pullCmd = &cobra.Command{
 		}
 
 		client := registry.NewClient()
-		idx, err := client.FetchAllIndexes(sources)
+		ctx := cmd.Context()
+		idx, err := client.FetchAllIndexes(ctx, sources)
 		if err != nil {
 			return fmt.Errorf("fetching indexes: %w", err)
 		}
@@ -85,7 +86,7 @@ var pullCmd = &cobra.Command{
 			}
 
 			logVerbose("downloading directory %s", entry.DownloadURL)
-			if err := client.DownloadDirectory(matchedSource, entry.DownloadURL, destPath); err != nil {
+			if err := client.DownloadDirectory(ctx, matchedSource, entry.DownloadURL, destPath); err != nil {
 				return fmt.Errorf("downloading skill directory: %w", err)
 			}
 
@@ -96,7 +97,7 @@ var pullCmd = &cobra.Command{
 			destPath := filepath.Join(pullDest, filename)
 
 			logVerbose("downloading %s", downloadURL)
-			if err := client.Download(downloadURL, destPath, token, username); err != nil {
+			if err := client.Download(ctx, downloadURL, destPath, token, username); err != nil {
 				return fmt.Errorf("downloading skill: %w", err)
 			}
 

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -25,7 +25,7 @@ var pullCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 
-		cfg, err := loadOrSetupConfig()
+		cfg, err := loadOrSetupConfig(cmd.Context())
 		if err != nil {
 			return err
 		}

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -20,7 +20,7 @@ var repoAddCmd = &cobra.Command{
 	Short: "Add a registry",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := loadOrSetupConfig()
+		cfg, err := loadOrSetupConfig(cmd.Context())
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,7 @@ var repoListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List registered registries",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := loadOrSetupConfig()
+		cfg, err := loadOrSetupConfig(cmd.Context())
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ var repoRemoveCmd = &cobra.Command{
 	Short: "Remove a registry",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := loadOrSetupConfig()
+		cfg, err := loadOrSetupConfig(cmd.Context())
 		if err != nil {
 			return err
 		}

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -37,10 +37,11 @@ var repoAddCmd = &cobra.Command{
 
 		// Detect default branch
 		client := registry.NewClient()
-		source.Branch = client.DetectDefaultBranch(source)
+		ctx := cmd.Context()
+		source.Branch = client.DetectDefaultBranch(ctx, source)
 
 		// Verify index is accessible
-		if _, err := client.FetchIndex(source); err != nil {
+		if _, err := client.FetchIndex(ctx, source); err != nil {
 			return fmt.Errorf("cannot access registry index: %w", err)
 		}
 

--- a/internal/cli/repo_update.go
+++ b/internal/cli/repo_update.go
@@ -31,6 +31,7 @@ var repoUpdateCmd = &cobra.Command{
 		}
 
 		client := registry.NewClient()
+		ctx := cmd.Context()
 		var updated int
 
 		for _, r := range cfg.Registries {
@@ -44,7 +45,7 @@ var repoUpdateCmd = &cobra.Command{
 			}
 
 			logVerbose("fetching index from %s", r.Name)
-			idx, err := client.FetchIndex(src)
+			idx, err := client.FetchIndex(ctx, src)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "WARNING: failed to update %q: %v\n", r.Name, err)
 				continue

--- a/internal/cli/repo_update.go
+++ b/internal/cli/repo_update.go
@@ -16,7 +16,7 @@ var repoUpdateCmd = &cobra.Command{
 	Short: "Fetch and cache registry indexes locally",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := loadOrSetupConfig()
+		cfg, err := loadOrSetupConfig(cmd.Context())
 		if err != nil {
 			return err
 		}

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -31,8 +31,9 @@ var searchCmd = &cobra.Command{
 		}
 
 		client := registry.NewClient()
+		ctx := cmd.Context()
 		logVerbose("fetching indexes from %d registry(ies)", len(sources))
-		idx, err := client.FetchAllIndexes(sources)
+		idx, err := client.FetchAllIndexes(ctx, sources)
 		if err != nil {
 			return fmt.Errorf("fetching indexes: %w", err)
 		}

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -20,7 +20,7 @@ var searchCmd = &cobra.Command{
 	Short: "Search for skills in registries (omit query to list all)",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := loadOrSetupConfig()
+		cfg, err := loadOrSetupConfig(cmd.Context())
 		if err != nil {
 			return err
 		}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -89,10 +90,11 @@ func loadOrSetupConfig() (*config.Config, error) {
 			}
 
 			client := registry.NewClient()
-			source.Branch = client.DetectDefaultBranch(source)
+			ctx := context.Background()
+			source.Branch = client.DetectDefaultBranch(ctx, source)
 
 			addRegistry := true
-			if _, fetchErr := client.FetchIndex(source); fetchErr != nil {
+			if _, fetchErr := client.FetchIndex(ctx, source); fetchErr != nil {
 				fmt.Fprintf(os.Stderr, "Warning: cannot access registry index (%v)\n", fetchErr)
 				fmt.Print("Add the registry anyway? [y/N]: ")
 				forceAnswer, _ := reader.ReadString('\n')

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -73,7 +73,9 @@ func loadOrSetupConfig() (*config.Config, error) {
 		source, err := registry.ParseRepoURL(repoURL)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to parse URL (%v), skipping registry.\n", err)
-		} else {
+		}
+
+		if err == nil {
 			fmt.Print("Enter token (press Enter to skip): ")
 			token, _ := reader.ReadString('\n')
 			token = strings.TrimSpace(token)
@@ -88,19 +90,16 @@ func loadOrSetupConfig() (*config.Config, error) {
 
 			client := registry.NewClient()
 			source.Branch = client.DetectDefaultBranch(source)
-			if _, err := client.FetchIndex(source); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: cannot access registry index (%v)\n", err)
+
+			addRegistry := true
+			if _, fetchErr := client.FetchIndex(source); fetchErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: cannot access registry index (%v)\n", fetchErr)
 				fmt.Print("Add the registry anyway? [y/N]: ")
 				forceAnswer, _ := reader.ReadString('\n')
-				forceAnswer = strings.TrimSpace(forceAnswer)
-				if strings.ToLower(forceAnswer) == "y" {
-					if err := cfg.AddRegistry(source.Name, source.URL, source.Token, source.Username, source.Branch, ""); err != nil {
-						fmt.Fprintf(os.Stderr, "Warning: failed to add registry (%v)\n", err)
-					} else {
-						fmt.Printf("Added registry '%s'.\n", source.Name)
-					}
-				}
-			} else {
+				addRegistry = strings.ToLower(strings.TrimSpace(forceAnswer)) == "y"
+			}
+
+			if addRegistry {
 				if err := cfg.AddRegistry(source.Name, source.URL, source.Token, source.Username, source.Branch, ""); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: failed to add registry (%v)\n", err)
 				} else {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -40,7 +40,7 @@ func registrySources(cfg *config.Config, repoFilter string) ([]registry.RepoSour
 	return sources, nil
 }
 
-func loadOrSetupConfig() (*config.Config, error) {
+func loadOrSetupConfig(ctx context.Context) (*config.Config, error) {
 	cfg, err := config.Load(paths.Config)
 	if err == nil {
 		return cfg, nil
@@ -90,7 +90,6 @@ func loadOrSetupConfig() (*config.Config, error) {
 			}
 
 			client := registry.NewClient()
-			ctx := context.Background()
 			source.Branch = client.DetectDefaultBranch(ctx, source)
 
 			addRegistry := true

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -27,7 +27,7 @@ var showManifestCmd = &cobra.Command{
 	Short: "Show raw skill.json",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		dir, cleanup, err := resolveSkillDir(args[0])
+		dir, cleanup, err := resolveSkillDir(cmd.Context(), args[0])
 		if err != nil {
 			return err
 		}
@@ -47,7 +47,7 @@ var showReadmeCmd = &cobra.Command{
 	Short: "Show SKILL.md",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		dir, cleanup, err := resolveSkillDir(args[0])
+		dir, cleanup, err := resolveSkillDir(cmd.Context(), args[0])
 		if err != nil {
 			return err
 		}
@@ -67,7 +67,7 @@ var showEntryCmd = &cobra.Command{
 	Short: "Show entry file content",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		dir, cleanup, err := resolveSkillDir(args[0])
+		dir, cleanup, err := resolveSkillDir(cmd.Context(), args[0])
 		if err != nil {
 			return err
 		}
@@ -92,7 +92,7 @@ var showAllCmd = &cobra.Command{
 	Short: "Show manifest and readme",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		dir, cleanup, err := resolveSkillDir(args[0])
+		dir, cleanup, err := resolveSkillDir(cmd.Context(), args[0])
 		if err != nil {
 			return err
 		}
@@ -136,7 +136,7 @@ func init() {
 // For installed skills, it returns the installed directory.
 // For remote skills, it downloads and extracts to a temp directory.
 // The caller must call cleanup() when done.
-func resolveSkillDir(name string) (dir string, cleanup func(), err error) {
+func resolveSkillDir(ctx context.Context, name string) (dir string, cleanup func(), err error) {
 	noop := func() {}
 
 	// 1. Check if installed locally
@@ -148,7 +148,7 @@ func resolveSkillDir(name string) (dir string, cleanup func(), err error) {
 	}
 
 	// 2. Fetch from registry
-	cfg, err := loadOrSetupConfig()
+	cfg, err := loadOrSetupConfig(ctx)
 	if err != nil {
 		return "", noop, err
 	}
@@ -163,7 +163,6 @@ func resolveSkillDir(name string) (dir string, cleanup func(), err error) {
 	}
 
 	client := registry.NewClient()
-	ctx := context.Background()
 	idx, err := client.FetchAllIndexes(ctx, sources)
 	if err != nil {
 		return "", noop, fmt.Errorf("fetching indexes: %w", err)

--- a/internal/cli/show.go
+++ b/internal/cli/show.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -162,7 +163,8 @@ func resolveSkillDir(name string) (dir string, cleanup func(), err error) {
 	}
 
 	client := registry.NewClient()
-	idx, err := client.FetchAllIndexes(sources)
+	ctx := context.Background()
+	idx, err := client.FetchAllIndexes(ctx, sources)
 	if err != nil {
 		return "", noop, fmt.Errorf("fetching indexes: %w", err)
 	}
@@ -209,7 +211,7 @@ func resolveSkillDir(name string) (dir string, cleanup func(), err error) {
 			return "", noop, fmt.Errorf("registry source not found for skill %q", name)
 		}
 		logVerbose("downloading directory %s", entry.DownloadURL)
-		if err := client.DownloadDirectory(matchedSource, entry.DownloadURL, extractDir); err != nil {
+		if err := client.DownloadDirectory(ctx, matchedSource, entry.DownloadURL, extractDir); err != nil {
 			cleanupFn()
 			return "", noop, fmt.Errorf("downloading skill directory: %w", err)
 		}
@@ -217,7 +219,7 @@ func resolveSkillDir(name string) (dir string, cleanup func(), err error) {
 		// Archive mode
 		archivePath := filepath.Join(tmpDir, "archive.tar.gz")
 		logVerbose("downloading %s", downloadURL)
-		if err := client.Download(downloadURL, archivePath, token, username); err != nil {
+		if err := client.Download(ctx, downloadURL, archivePath, token, username); err != nil {
 			cleanupFn()
 			return "", noop, fmt.Errorf("downloading skill: %w", err)
 		}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -15,7 +15,7 @@ var updateCmd = &cobra.Command{
 	Use:   "update [skill]",
 	Short: "Update installed skills",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := loadOrSetupConfig()
+		cfg, err := loadOrSetupConfig(cmd.Context())
 		if err != nil {
 			return err
 		}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
 var updateCmd = &cobra.Command{
 	Use:   "update [skill]",
 	Short: "Update installed skills",

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+
 var updateCmd = &cobra.Command{
 	Use:   "update [skill]",
 	Short: "Update installed skills",
@@ -30,7 +31,8 @@ var updateCmd = &cobra.Command{
 		}
 
 		client := registry.NewClient()
-		idx, err := client.FetchAllIndexes(sources)
+		ctx := cmd.Context()
+		idx, err := client.FetchAllIndexes(ctx, sources)
 		if err != nil {
 			return fmt.Errorf("fetching indexes: %w", err)
 		}
@@ -86,7 +88,7 @@ var updateCmd = &cobra.Command{
 			}
 
 			fmt.Printf("%s: updating %s -> %s\n", name, s.Manifest.Version, entry.Version)
-			if err := inst.Install(name, true, false); err != nil {
+			if err := inst.Install(ctx, name, true, false); err != nil {
 				fmt.Printf("%s: update failed: %v\n", name, err)
 				continue
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,4 @@
+// Package config manages skillhub configuration loading and persistence.
 package config
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// RegistryEntry holds the configuration for a single remote skill registry.
 type RegistryEntry struct {
 	Name         string `yaml:"name"`
 	URL          string `yaml:"url"`
@@ -18,6 +19,7 @@ type RegistryEntry struct {
 	SkillsPrefix string `yaml:"skills_prefix,omitempty"`
 }
 
+// Config holds the user's skillhub configuration.
 type Config struct {
 	Registries []RegistryEntry `yaml:"registries"`
 	InstallDir string          `yaml:"install_dir"`
@@ -25,6 +27,7 @@ type Config struct {
 	LogDir     string          `yaml:"log_dir"`
 }
 
+// DefaultConfig returns a Config with default directory paths rooted at home.
 func DefaultConfig(home string) *Config {
 	return &Config{
 		Registries: []RegistryEntry{},
@@ -34,6 +37,7 @@ func DefaultConfig(home string) *Config {
 	}
 }
 
+// Load reads and parses the YAML configuration file at the given path.
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -48,6 +52,7 @@ func Load(path string) (*Config, error) {
 	return &cfg, nil
 }
 
+// Save writes the configuration to the given path as YAML.
 func (c *Config) Save(path string) error {
 	data, err := yaml.Marshal(c)
 	if err != nil {
@@ -61,6 +66,7 @@ func (c *Config) Save(path string) error {
 	return nil
 }
 
+// Validate checks that all registry entries have required fields.
 func (c *Config) Validate() error {
 	for i, r := range c.Registries {
 		if r.Name == "" {
@@ -73,6 +79,7 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+// AddRegistry upserts a registry entry by name, updating it if it already exists.
 func (c *Config) AddRegistry(name, rawURL, token, username, branch, skillsPrefix string) error {
 	for i, r := range c.Registries {
 		if r.Name == name {
@@ -88,6 +95,7 @@ func (c *Config) AddRegistry(name, rawURL, token, username, branch, skillsPrefix
 	return nil
 }
 
+// RemoveRegistry removes the registry with the given name, returning an error if not found.
 func (c *Config) RemoveRegistry(name string) error {
 	for i, r := range c.Registries {
 		if r.Name == name {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,10 +72,10 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func (c *Config) AddRegistry(name, url, token, username, branch, skillsPrefix string) error {
+func (c *Config) AddRegistry(name, rawURL, token, username, branch, skillsPrefix string) error {
 	for i, r := range c.Registries {
 		if r.Name == name {
-			c.Registries[i].URL = url
+			c.Registries[i].URL = rawURL
 			c.Registries[i].Token = token
 			c.Registries[i].Username = username
 			c.Registries[i].Branch = branch
@@ -83,7 +83,7 @@ func (c *Config) AddRegistry(name, url, token, username, branch, skillsPrefix st
 			return nil
 		}
 	}
-	c.Registries = append(c.Registries, RegistryEntry{Name: name, URL: url, Token: token, Username: username, Branch: branch, SkillsPrefix: skillsPrefix})
+	c.Registries = append(c.Registries, RegistryEntry{Name: name, URL: rawURL, Token: token, Username: username, Branch: branch, SkillsPrefix: skillsPrefix})
 	return nil
 }
 

--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -1,3 +1,4 @@
+// Package installer downloads, extracts, and verifies skill archives.
 package installer
 
 import (

--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -2,6 +2,7 @@
 package installer
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -38,7 +39,7 @@ func (inst *Installer) logVerbose(format string, args ...any) {
 	}
 }
 
-func (inst *Installer) Install(name string, force bool, global bool) error {
+func (inst *Installer) Install(ctx context.Context, name string, force bool, global bool) error {
 	// 1. Check if already installed
 	inst.logVerbose("checking if %q is already installed", name)
 	if !force && storage.IsInstalled(inst.Paths, name) {
@@ -72,7 +73,7 @@ func (inst *Installer) Install(name string, force bool, global bool) error {
 
 	// 3. Fetch and merge all indexes
 	inst.logVerbose("fetching indexes from %d registry(ies)", len(sources))
-	idx, err := inst.Client.FetchAllIndexes(sources)
+	idx, err := inst.Client.FetchAllIndexes(ctx, sources)
 	if err != nil {
 		return fmt.Errorf("fetching indexes: %w", err)
 	}
@@ -125,14 +126,14 @@ func (inst *Installer) Install(name string, force bool, global bool) error {
 		inst.Client.OnProgress = func(filename string) {
 			inst.logVerbose("  %s", filename)
 		}
-		if err := inst.Client.DownloadDirectory(matchedSource, entry.DownloadURL, tmpDir); err != nil {
+		if err := inst.Client.DownloadDirectory(ctx, matchedSource, entry.DownloadURL, tmpDir); err != nil {
 			return fmt.Errorf("downloading skill directory: %w", err)
 		}
 	} else {
 		// Archive mode: download tar.gz, verify, extract
 		cacheFile := filepath.Join(inst.Paths.CacheDir, fmt.Sprintf("%s-%s.tar.gz", name, entry.Version))
 		inst.logVerbose("downloading %s to %s", downloadURL, cacheFile)
-		if err := inst.Client.Download(downloadURL, cacheFile, token, username); err != nil {
+		if err := inst.Client.Download(ctx, downloadURL, cacheFile, token, username); err != nil {
 			return fmt.Errorf("downloading skill: %w", err)
 		}
 

--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jayl2kor/skillhub/internal/storage"
 )
 
+// Installer downloads, verifies, and installs skills from a registry.
 type Installer struct {
 	Paths      *storage.Paths
 	Config     *config.Config
@@ -24,6 +25,7 @@ type Installer struct {
 	RepoFilter string // filter by registry name (empty = all)
 }
 
+// NewInstaller creates an Installer configured with the given paths and config.
 func NewInstaller(paths *storage.Paths, cfg *config.Config) *Installer {
 	return &Installer{
 		Paths:   paths,
@@ -39,6 +41,9 @@ func (inst *Installer) logVerbose(format string, args ...any) {
 	}
 }
 
+// Install resolves, downloads, verifies, and installs the named skill.
+// If force is true, an existing installation is overwritten.
+// If global is true, the skill is installed to the agent's home skills directory.
 func (inst *Installer) Install(ctx context.Context, name string, force bool, global bool) error {
 	// 1. Check if already installed
 	inst.logVerbose("checking if %q is already installed", name)

--- a/internal/installer/install_test.go
+++ b/internal/installer/install_test.go
@@ -3,6 +3,7 @@ package installer
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -99,7 +100,7 @@ func TestInstall(t *testing.T) {
 
 	inst := NewInstaller(paths, cfg)
 
-	if err := inst.Install("test-skill", false, false); err != nil {
+	if err := inst.Install(context.Background(),"test-skill", false, false); err != nil {
 		t.Fatalf("Install: %v", err)
 	}
 
@@ -132,16 +133,16 @@ func TestInstallAlreadyInstalled(t *testing.T) {
 
 	inst := NewInstaller(paths, cfg)
 
-	if err := inst.Install("test-skill", false, false); err != nil {
+	if err := inst.Install(context.Background(),"test-skill", false, false); err != nil {
 		t.Fatalf("first Install: %v", err)
 	}
 
-	err := inst.Install("test-skill", false, false)
+	err := inst.Install(context.Background(),"test-skill", false, false)
 	if err == nil {
 		t.Error("expected error for already installed skill")
 	}
 
-	if err := inst.Install("test-skill", true, false); err != nil {
+	if err := inst.Install(context.Background(),"test-skill", true, false); err != nil {
 		t.Errorf("force Install: %v", err)
 	}
 }
@@ -165,7 +166,7 @@ func TestInstallNotFound(t *testing.T) {
 	}
 
 	inst := NewInstaller(paths, cfg)
-	err := inst.Install("nonexistent", false, false)
+	err := inst.Install(context.Background(),"nonexistent", false, false)
 	if err == nil {
 		t.Error("expected error for nonexistent skill")
 	}
@@ -233,7 +234,7 @@ func TestInstallDirectoryMode(t *testing.T) {
 
 	inst := NewInstaller(paths, cfg)
 
-	if err := inst.Install("dir-skill", false, false); err != nil {
+	if err := inst.Install(context.Background(),"dir-skill", false, false); err != nil {
 		t.Fatalf("Install directory mode: %v", err)
 	}
 
@@ -266,18 +267,18 @@ func TestInstallDirectoryModeForceReinstall(t *testing.T) {
 
 	inst := NewInstaller(paths, cfg)
 
-	if err := inst.Install("dir-skill", false, false); err != nil {
+	if err := inst.Install(context.Background(),"dir-skill", false, false); err != nil {
 		t.Fatalf("first Install: %v", err)
 	}
 
 	// Should fail without --force
-	err := inst.Install("dir-skill", false, false)
+	err := inst.Install(context.Background(),"dir-skill", false, false)
 	if err == nil {
 		t.Error("expected error for already installed skill")
 	}
 
 	// Should succeed with --force
-	if err := inst.Install("dir-skill", true, false); err != nil {
+	if err := inst.Install(context.Background(),"dir-skill", true, false); err != nil {
 		t.Errorf("force Install directory mode: %v", err)
 	}
 }
@@ -292,7 +293,7 @@ func TestInstallNoRegistries(t *testing.T) {
 	cfg := &config.Config{}
 
 	inst := NewInstaller(paths, cfg)
-	err := inst.Install("test", false, false)
+	err := inst.Install(context.Background(),"test", false, false)
 	if err == nil {
 		t.Error("expected error when no registries configured")
 	}

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -73,7 +73,8 @@ func TestFullWorkflow(t *testing.T) {
 	// Step 3: Search
 	sources := []registry.RepoSource{{Name: "test-reg", URL: regDir}}
 	client := registry.NewClient()
-	fetchedIdx, err := client.FetchAllIndexes(sources)
+	ctx := context.Background()
+	fetchedIdx, err := client.FetchAllIndexes(ctx, sources)
 	if err != nil {
 		t.Fatalf("FetchAllIndexes: %v", err)
 	}
@@ -88,7 +89,7 @@ func TestFullWorkflow(t *testing.T) {
 
 	// Step 4: Install
 	inst := installer.NewInstaller(paths, cfg)
-	if err := inst.Install("test-prompt", false, false); err != nil {
+	if err := inst.Install(ctx, "test-prompt", false, false); err != nil {
 		t.Fatalf("Install: %v", err)
 	}
 

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -144,10 +144,12 @@ func (c *Client) Download(ctx context.Context, rawURL, dest, token, username str
 	tmpPath := tmpFile.Name()
 	defer os.Remove(tmpPath)
 
-	n, err := io.Copy(tmpFile, io.LimitReader(resp.Body, maxDownloadSize+1))
-	tmpFile.Close()
-	if err != nil {
-		return fmt.Errorf("writing download to %s: %w", dest, err)
+	n, copyErr := io.Copy(tmpFile, io.LimitReader(resp.Body, maxDownloadSize+1))
+	if closeErr := tmpFile.Close(); closeErr != nil && copyErr == nil {
+		return fmt.Errorf("closing temp download file: %w", closeErr)
+	}
+	if copyErr != nil {
+		return fmt.Errorf("writing download to %s: %w", dest, copyErr)
 	}
 	if n > maxDownloadSize {
 		return fmt.Errorf("download from %s exceeds maximum size (%d bytes)", rawURL, maxDownloadSize)

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -100,7 +100,6 @@ func (c *Client) FetchAllIndexes(sources []RepoSource) (*Index, error) {
 	var indexes []*Index
 
 	for _, src := range sources {
-		src := src
 		idx, err := c.FetchIndex(&src)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to fetch from %s: %v\n", src.Name, err)

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -1,3 +1,4 @@
+// Package registry handles communication with remote skill registries.
 package registry
 
 import (

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -2,6 +2,7 @@
 package registry
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -45,7 +46,7 @@ func NewClient() *Client {
 // DetectDefaultBranch queries the GitHub API to find the default branch.
 // For non-github.com hosts, it uses the /api/v3/ endpoint.
 // Returns "main" as fallback if detection fails.
-func (c *Client) DetectDefaultBranch(source *RepoSource) string {
+func (c *Client) DetectDefaultBranch(ctx context.Context, source *RepoSource) string {
 	if isLocalPath(source.URL) {
 		return "main"
 	}
@@ -63,7 +64,7 @@ func (c *Client) DetectDefaultBranch(source *RepoSource) string {
 		apiURL = fmt.Sprintf("%s://%s/api/v3/repos/%s", u.Scheme, u.Host, ownerRepo)
 	}
 
-	data, err := c.fetch(apiURL, source.Token, source.Username)
+	data, err := c.fetch(ctx, apiURL, source.Token, source.Username)
 	if err != nil {
 		return "main"
 	}
@@ -77,10 +78,10 @@ func (c *Client) DetectDefaultBranch(source *RepoSource) string {
 	return repo.DefaultBranch
 }
 
-func (c *Client) FetchIndex(source *RepoSource) (*Index, error) {
+func (c *Client) FetchIndex(ctx context.Context, source *RepoSource) (*Index, error) {
 	indexURL := source.IndexURL()
 
-	data, err := c.fetch(indexURL, source.Token, source.Username)
+	data, err := c.fetch(ctx, indexURL, source.Token, source.Username)
 	if err != nil {
 		return nil, fmt.Errorf("fetching index from %s: %w", source.Name, err)
 	}
@@ -97,11 +98,11 @@ func (c *Client) FetchIndex(source *RepoSource) (*Index, error) {
 	return idx, nil
 }
 
-func (c *Client) FetchAllIndexes(sources []RepoSource) (*Index, error) {
+func (c *Client) FetchAllIndexes(ctx context.Context, sources []RepoSource) (*Index, error) {
 	var indexes []*Index
 
 	for _, src := range sources {
-		idx, err := c.FetchIndex(&src)
+		idx, err := c.FetchIndex(ctx, &src)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to fetch from %s: %v\n", src.Name, err)
 			continue
@@ -112,7 +113,7 @@ func (c *Client) FetchAllIndexes(sources []RepoSource) (*Index, error) {
 	return MergeIndexes(indexes...), nil
 }
 
-func (c *Client) Download(rawURL, dest, token, username string) error {
+func (c *Client) Download(ctx context.Context, rawURL, dest, token, username string) error {
 	if isLocalPath(rawURL) {
 		data, err := os.ReadFile(rawURL)
 		if err != nil {
@@ -121,7 +122,7 @@ func (c *Client) Download(rawURL, dest, token, username string) error {
 		return os.WriteFile(dest, data, 0644)
 	}
 
-	req, err := c.newRequest(rawURL, token, username)
+	req, err := c.newRequest(ctx, rawURL, token, username)
 	if err != nil {
 		return fmt.Errorf("creating request for %s: %w", rawURL, err)
 	}
@@ -169,7 +170,7 @@ type githubContentEntry struct {
 // DownloadDirectory downloads all files from a directory source into destDir.
 // For local paths, it copies the directory tree. For GitHub, it uses the Contents API.
 // If OnProgress is set, it is called with each file's relative name after download.
-func (c *Client) DownloadDirectory(source *RepoSource, dirPath, destDir string) error {
+func (c *Client) DownloadDirectory(ctx context.Context, source *RepoSource, dirPath, destDir string) error {
 	dirPath = strings.TrimSuffix(dirPath, "/")
 
 	if isLocalPath(source.URL) {
@@ -177,7 +178,7 @@ func (c *Client) DownloadDirectory(source *RepoSource, dirPath, destDir string) 
 		return c.copyDirectory(srcDir, destDir)
 	}
 
-	return c.downloadGitHubDirectory(source, dirPath, destDir)
+	return c.downloadGitHubDirectory(ctx, source, dirPath, destDir)
 }
 
 func (c *Client) copyDirectory(srcDir, destDir string) error {
@@ -223,10 +224,10 @@ func (c *Client) copyDirectory(srcDir, destDir string) error {
 // maxConcurrentDownloads limits the number of concurrent file downloads.
 const maxConcurrentDownloads = 8
 
-func (c *Client) downloadGitHubDirectory(source *RepoSource, dirPath, destDir string) error {
+func (c *Client) downloadGitHubDirectory(ctx context.Context, source *RepoSource, dirPath, destDir string) error {
 	apiURL := source.ContentsAPIURL(dirPath)
 
-	data, err := c.fetch(apiURL, source.Token, source.Username)
+	data, err := c.fetch(ctx, apiURL, source.Token, source.Username)
 	if err != nil {
 		return fmt.Errorf("listing directory %s: %w", dirPath, err)
 	}
@@ -253,7 +254,7 @@ func (c *Client) downloadGitHubDirectory(source *RepoSource, dirPath, destDir st
 		if err := os.MkdirAll(destPath, 0755); err != nil {
 			return fmt.Errorf("creating directory %s: %w", destPath, err)
 		}
-		if err := c.downloadGitHubDirectory(source, entry.Path, destPath); err != nil {
+		if err := c.downloadGitHubDirectory(ctx, source, entry.Path, destPath); err != nil {
 			return err
 		}
 	}
@@ -280,7 +281,7 @@ func (c *Client) downloadGitHubDirectory(source *RepoSource, dirPath, destDir st
 
 			destPath := filepath.Join(destDir, entry.Name)
 			downloadURL := source.ResolveDownloadURL(entry.Path)
-			if err := c.Download(downloadURL, destPath, source.Token, source.Username); err != nil {
+			if err := c.Download(ctx, downloadURL, destPath, source.Token, source.Username); err != nil {
 				mu.Lock()
 				if firstErr == nil {
 					firstErr = fmt.Errorf("downloading %s: %w", entry.Name, err)
@@ -298,8 +299,8 @@ func (c *Client) downloadGitHubDirectory(source *RepoSource, dirPath, destDir st
 	return firstErr
 }
 
-func (c *Client) newRequest(rawURL, token, username string) (*http.Request, error) {
-	req, err := http.NewRequest("GET", rawURL, nil)
+func (c *Client) newRequest(ctx context.Context, rawURL, token, username string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", rawURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -353,12 +354,12 @@ func checkResponse(resp *http.Response, rawURL, token string) error {
 	return nil
 }
 
-func (c *Client) fetch(rawURL, token, username string) ([]byte, error) {
+func (c *Client) fetch(ctx context.Context, rawURL, token, username string) ([]byte, error) {
 	if isLocalPath(rawURL) {
 		return os.ReadFile(rawURL)
 	}
 
-	req, err := c.newRequest(rawURL, token, username)
+	req, err := c.newRequest(ctx, rawURL, token, username)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -21,11 +21,13 @@ const (
 	maxAPIResponseSize = 10 * 1024 * 1024  // 10MB for API/JSON responses
 )
 
+// Client communicates with remote skill registries over HTTP.
 type Client struct {
 	HTTPClient *http.Client
 	OnProgress func(filename string) // called for each file downloaded in directory mode
 }
 
+// NewClient creates a Client with a 30-second timeout and safe redirect policy.
 func NewClient() *Client {
 	return &Client{
 		HTTPClient: &http.Client{
@@ -78,6 +80,7 @@ func (c *Client) DetectDefaultBranch(ctx context.Context, source *RepoSource) st
 	return repo.DefaultBranch
 }
 
+// FetchIndex downloads and parses the index.json from the given registry source.
 func (c *Client) FetchIndex(ctx context.Context, source *RepoSource) (*Index, error) {
 	indexURL := source.IndexURL()
 
@@ -98,6 +101,7 @@ func (c *Client) FetchIndex(ctx context.Context, source *RepoSource) (*Index, er
 	return idx, nil
 }
 
+// FetchAllIndexes fetches and merges indexes from all sources, logging warnings for failures.
 func (c *Client) FetchAllIndexes(ctx context.Context, sources []RepoSource) (*Index, error) {
 	var indexes []*Index
 
@@ -113,6 +117,8 @@ func (c *Client) FetchAllIndexes(ctx context.Context, sources []RepoSource) (*In
 	return MergeIndexes(indexes...), nil
 }
 
+// Download fetches rawURL and writes the result to dest, enforcing a 500 MB size limit.
+// For local file paths, it copies the file directly without HTTP.
 func (c *Client) Download(ctx context.Context, rawURL, dest, token, username string) error {
 	if isLocalPath(rawURL) {
 		data, err := os.ReadFile(rawURL)

--- a/internal/registry/client_test.go
+++ b/internal/registry/client_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -23,7 +24,8 @@ func TestFetchIndexLocal(t *testing.T) {
 	client := NewClient()
 	source := &RepoSource{Name: "local", URL: dir}
 
-	idx, err := client.FetchIndex(source)
+	ctx := context.Background()
+	idx, err := client.FetchIndex(ctx, source)
 	if err != nil {
 		t.Fatalf("FetchIndex: %v", err)
 	}
@@ -53,7 +55,8 @@ func TestFetchIndexHTTP(t *testing.T) {
 	client := NewClient()
 
 	// Direct fetch test
-	data, err := client.fetch(server.URL, "", "")
+	ctx := context.Background()
+	data, err := client.fetch(ctx, server.URL, "", "")
 	if err != nil {
 		t.Fatalf("fetch: %v", err)
 	}
@@ -87,7 +90,8 @@ func TestFetchAllIndexes(t *testing.T) {
 		{Name: "reg2", URL: dir2},
 	}
 
-	idx, err := client.FetchAllIndexes(sources)
+	ctx := context.Background()
+	idx, err := client.FetchAllIndexes(ctx, sources)
 	if err != nil {
 		t.Fatalf("FetchAllIndexes: %v", err)
 	}
@@ -109,7 +113,8 @@ func TestDownload(t *testing.T) {
 	dest := filepath.Join(dir, "downloaded")
 
 	client := NewClient()
-	if err := client.Download(server.URL, dest, "", ""); err != nil {
+	ctx := context.Background()
+	if err := client.Download(ctx, server.URL, dest, "", ""); err != nil {
 		t.Fatalf("Download: %v", err)
 	}
 
@@ -140,7 +145,8 @@ func TestDownloadExceedsMaxSize(t *testing.T) {
 	dest := filepath.Join(dir, "downloaded")
 
 	client := NewClient()
-	if err := client.Download(server.URL, dest, "", ""); err != nil {
+	ctx := context.Background()
+	if err := client.Download(ctx, server.URL, dest, "", ""); err != nil {
 		t.Fatalf("Download should succeed for small content: %v", err)
 	}
 }
@@ -160,7 +166,8 @@ func TestFetchExceedsMaxAPIResponseSize(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient()
-	_, err := client.fetch(server.URL, "", "")
+	ctx := context.Background()
+	_, err := client.fetch(ctx, server.URL, "", "")
 	if err == nil {
 		t.Fatal("expected error for oversized API response")
 	}
@@ -175,7 +182,8 @@ func TestDownloadLocal(t *testing.T) {
 
 	dest := filepath.Join(dir, "dest.tar.gz")
 	client := NewClient()
-	if err := client.Download(srcFile, dest, "", ""); err != nil {
+	ctx := context.Background()
+	if err := client.Download(ctx, srcFile, dest, "", ""); err != nil {
 		t.Fatalf("local Download: %v", err)
 	}
 
@@ -254,9 +262,10 @@ func TestDownloadDirectoryLocal(t *testing.T) {
 	// Download directory
 	destDir := t.TempDir()
 	client := NewClient()
+	ctx := context.Background()
 	source := &RepoSource{Name: "local", URL: srcDir}
 
-	if err := client.DownloadDirectory(source, "skills/my-skill/", destDir); err != nil {
+	if err := client.DownloadDirectory(ctx, source, "skills/my-skill/", destDir); err != nil {
 		t.Fatalf("DownloadDirectory: %v", err)
 	}
 
@@ -311,9 +320,10 @@ func TestDownloadDirectoryLocalSkipsHiddenFiles(t *testing.T) {
 
 	destDir := t.TempDir()
 	client := NewClient()
+	ctx := context.Background()
 	source := &RepoSource{Name: "local", URL: srcDir}
 
-	if err := client.DownloadDirectory(source, "skills/my-skill/", destDir); err != nil {
+	if err := client.DownloadDirectory(ctx, source, "skills/my-skill/", destDir); err != nil {
 		t.Fatalf("DownloadDirectory: %v", err)
 	}
 
@@ -367,7 +377,8 @@ func TestDownloadDirectoryGitHub(t *testing.T) {
 
 	destDir := t.TempDir()
 	client := NewClient()
-	if err := client.DownloadDirectory(source, "skills/test-skill/", destDir); err != nil {
+	ctx := context.Background()
+	if err := client.DownloadDirectory(ctx, source, "skills/test-skill/", destDir); err != nil {
 		t.Fatalf("DownloadDirectory GitHub: %v", err)
 	}
 
@@ -428,7 +439,8 @@ func TestDownloadDirectoryGitHubConcurrent(t *testing.T) {
 
 	destDir := t.TempDir()
 	client := NewClient()
-	if err := client.DownloadDirectory(source, "skills/many-files/", destDir); err != nil {
+	ctx := context.Background()
+	if err := client.DownloadDirectory(ctx, source, "skills/many-files/", destDir); err != nil {
 		t.Fatalf("DownloadDirectory: %v", err)
 	}
 

--- a/internal/registry/index.go
+++ b/internal/registry/index.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 )
 
+// IndexEntry describes a single skill in a registry index.
 type IndexEntry struct {
 	Name        string   `json:"name"`
 	Version     string   `json:"version"`
@@ -16,10 +17,12 @@ type IndexEntry struct {
 	Registry    string   `json:"-"`
 }
 
+// Index holds the full list of skills available in a registry.
 type Index struct {
 	Skills []IndexEntry `json:"skills"`
 }
 
+// ParseIndex unmarshals JSON data into an Index.
 func ParseIndex(data []byte) (*Index, error) {
 	var idx Index
 	if err := json.Unmarshal(data, &idx); err != nil {
@@ -28,6 +31,7 @@ func ParseIndex(data []byte) (*Index, error) {
 	return &idx, nil
 }
 
+// Search returns entries whose name, description, or tags match the query.
 func (idx *Index) Search(query string) []IndexEntry {
 	if query == "*" || query == "" {
 		return idx.Skills
@@ -60,6 +64,7 @@ func matchesQuery(entry IndexEntry, query string) bool {
 	return false
 }
 
+// Find returns the first entry with the given name, or nil if not found.
 func (idx *Index) Find(name string) *IndexEntry {
 	for _, entry := range idx.Skills {
 		if entry.Name == name {
@@ -79,6 +84,7 @@ func (idx *Index) FindVersion(name, version string) *IndexEntry {
 	return nil
 }
 
+// MergeIndexes combines multiple indexes into a single unified index.
 func MergeIndexes(indexes ...*Index) *Index {
 	merged := &Index{}
 	for _, idx := range indexes {

--- a/internal/registry/upload.go
+++ b/internal/registry/upload.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -24,14 +25,14 @@ type githubFileInfo struct {
 
 // GetFileSHA returns the blob SHA of a file in a GitHub repository.
 // Returns "" if the file does not exist (404).
-func (c *Client) GetFileSHA(source *RepoSource, path string) (string, error) {
+func (c *Client) GetFileSHA(ctx context.Context, source *RepoSource, path string) (string, error) {
 	if source.IsLocal() {
 		return "", nil
 	}
 
 	apiURL := source.ContentsAPIPutURL(path) + "?ref=" + source.branch()
 
-	req, err := c.newRequest(apiURL, source.Token, source.Username)
+	req, err := c.newRequest(ctx, apiURL, source.Token, source.Username)
 	if err != nil {
 		return "", fmt.Errorf("creating request: %w", err)
 	}
@@ -64,7 +65,7 @@ func (c *Client) GetFileSHA(source *RepoSource, path string) (string, error) {
 
 // UploadFile uploads content to a registry. For local registries it writes
 // directly to the filesystem. For GitHub it uses the Contents API.
-func (c *Client) UploadFile(source *RepoSource, path string, content []byte, sha, message string) error {
+func (c *Client) UploadFile(ctx context.Context, source *RepoSource, path string, content []byte, sha, message string) error {
 	if source.IsLocal() {
 		dest := filepath.Join(source.URL, path)
 		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
@@ -87,7 +88,7 @@ func (c *Client) UploadFile(source *RepoSource, path string, content []byte, sha
 		return fmt.Errorf("marshaling request: %w", err)
 	}
 
-	req, err := http.NewRequest("PUT", apiURL, bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, "PUT", apiURL, bytes.NewReader(jsonBody))
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
 	}
@@ -120,7 +121,7 @@ func (c *Client) UploadFile(source *RepoSource, path string, content []byte, sha
 // UploadDirectory uploads all files from srcDir to destPrefix in the registry.
 // For local registries it copies the directory tree. For GitHub it uploads
 // each file via the Contents API. Hidden files/directories are skipped.
-func (c *Client) UploadDirectory(source *RepoSource, srcDir, destPrefix, message string) error {
+func (c *Client) UploadDirectory(ctx context.Context, source *RepoSource, srcDir, destPrefix, message string) error {
 	if source.IsLocal() {
 		destDir := filepath.Join(source.URL, destPrefix)
 		if err := os.MkdirAll(destDir, 0755); err != nil {
@@ -178,12 +179,12 @@ func (c *Client) UploadDirectory(source *RepoSource, srcDir, destPrefix, message
 			return fmt.Errorf("reading %s: %w", rel, err)
 		}
 
-		sha, err := c.GetFileSHA(source, remotePath)
+		sha, err := c.GetFileSHA(ctx, source, remotePath)
 		if err != nil {
 			return fmt.Errorf("checking %s: %w", remotePath, err)
 		}
 
-		if err := c.UploadFile(source, remotePath, content, sha, message); err != nil {
+		if err := c.UploadFile(ctx, source, remotePath, content, sha, message); err != nil {
 			return fmt.Errorf("uploading %s: %w", rel, err)
 		}
 
@@ -197,7 +198,7 @@ func (c *Client) UploadDirectory(source *RepoSource, srcDir, destPrefix, message
 // UpdateIndex fetches the current index.json from the registry, upserts the
 // given entry, and writes it back. If force is false and a matching
 // name+version already exists, it returns an error.
-func (c *Client) UpdateIndex(source *RepoSource, entry IndexEntry, force bool) error {
+func (c *Client) UpdateIndex(ctx context.Context, source *RepoSource, entry IndexEntry, force bool) error {
 	idx := &Index{}
 
 	if source.IsLocal() {
@@ -210,7 +211,7 @@ func (c *Client) UpdateIndex(source *RepoSource, entry IndexEntry, force bool) e
 			}
 		}
 	} else {
-		data, err := c.fetch(source.IndexURL(), source.Token, source.Username)
+		data, err := c.fetch(ctx, source.IndexURL(), source.Token, source.Username)
 		if err == nil {
 			parsed, parseErr := ParseIndex(data)
 			if parseErr == nil {
@@ -247,11 +248,11 @@ func (c *Client) UpdateIndex(source *RepoSource, entry IndexEntry, force bool) e
 		return os.WriteFile(filepath.Join(source.URL, "index.json"), indexData, 0644)
 	}
 
-	sha, err := c.GetFileSHA(source, "index.json")
+	sha, err := c.GetFileSHA(ctx, source, "index.json")
 	if err != nil {
 		return fmt.Errorf("getting index.json SHA: %w", err)
 	}
 
 	msg := fmt.Sprintf("update index: %s@%s", entry.Name, entry.Version)
-	return c.UploadFile(source, "index.json", indexData, sha, msg)
+	return c.UploadFile(ctx, source, "index.json", indexData, sha, msg)
 }

--- a/internal/registry/upload_test.go
+++ b/internal/registry/upload_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -89,7 +90,8 @@ func TestGetFileSHA(t *testing.T) {
 		Branch: "main",
 	}
 
-	sha, err := client.GetFileSHA(source, "skills/my-skill/skill.json")
+	ctx := context.Background()
+	sha, err := client.GetFileSHA(ctx, source, "skills/my-skill/skill.json")
 	if err != nil {
 		t.Fatalf("GetFileSHA existing: %v", err)
 	}
@@ -97,7 +99,7 @@ func TestGetFileSHA(t *testing.T) {
 		t.Errorf("expected sha abc123, got %q", sha)
 	}
 
-	sha, err = client.GetFileSHA(source, "skills/my-skill/missing.md")
+	sha, err = client.GetFileSHA(ctx, source, "skills/my-skill/missing.md")
 	if err != nil {
 		t.Fatalf("GetFileSHA missing: %v", err)
 	}
@@ -136,8 +138,9 @@ func TestUploadFileGitHub(t *testing.T) {
 		Token:  "test-token",
 	}
 
+	ctx := context.Background()
 	content := []byte(`{"name":"my-skill"}`)
-	err := client.UploadFile(source, "skills/my-skill/skill.json", content, "", "publish my-skill@1.0.0")
+	err := client.UploadFile(ctx, source, "skills/my-skill/skill.json", content, "", "publish my-skill@1.0.0")
 	if err != nil {
 		t.Fatalf("UploadFile: %v", err)
 	}
@@ -162,8 +165,9 @@ func TestUploadFileLocal(t *testing.T) {
 	client := NewClient()
 	source := &RepoSource{URL: dir}
 
+	ctx := context.Background()
 	content := []byte(`{"name":"my-skill"}`)
-	err := client.UploadFile(source, "skills/my-skill/skill.json", content, "", "")
+	err := client.UploadFile(ctx, source, "skills/my-skill/skill.json", content, "", "")
 	if err != nil {
 		t.Fatalf("UploadFile local: %v", err)
 	}
@@ -199,9 +203,10 @@ func TestUploadDirectoryLocal(t *testing.T) {
 
 	regDir := t.TempDir()
 	client := NewClient()
+	ctx := context.Background()
 	source := &RepoSource{Name: "local", URL: regDir}
 
-	if err := client.UploadDirectory(source, srcDir, "skills/test", "publish"); err != nil {
+	if err := client.UploadDirectory(ctx, source, srcDir, "skills/test", "publish"); err != nil {
 		t.Fatalf("UploadDirectory: %v", err)
 	}
 
@@ -267,7 +272,8 @@ func TestUploadDirectoryGitHub(t *testing.T) {
 		Token:  "tok",
 	}
 
-	if err := client.UploadDirectory(source, srcDir, "skills/test", "publish test@1.0.0"); err != nil {
+	ctx := context.Background()
+	if err := client.UploadDirectory(ctx, source, srcDir, "skills/test", "publish test@1.0.0"); err != nil {
 		t.Fatalf("UploadDirectory GitHub: %v", err)
 	}
 
@@ -296,8 +302,10 @@ func TestUpdateIndexLocal(t *testing.T) {
 		DownloadURL: "skills/my-skill/",
 	}
 
+	ctx := context.Background()
+
 	// First publish: creates index.json
-	if err := client.UpdateIndex(source, entry, false); err != nil {
+	if err := client.UpdateIndex(ctx, source, entry, false); err != nil {
 		t.Fatalf("UpdateIndex create: %v", err)
 	}
 
@@ -317,14 +325,14 @@ func TestUpdateIndexLocal(t *testing.T) {
 	}
 
 	// Duplicate without force: should error
-	err = client.UpdateIndex(source, entry, false)
+	err = client.UpdateIndex(ctx, source, entry, false)
 	if err == nil {
 		t.Fatal("expected error for duplicate version without force")
 	}
 
 	// Duplicate with force: should succeed
 	entry.Description = "updated skill"
-	if err := client.UpdateIndex(source, entry, true); err != nil {
+	if err := client.UpdateIndex(ctx, source, entry, true); err != nil {
 		t.Fatalf("UpdateIndex force: %v", err)
 	}
 
@@ -350,7 +358,7 @@ func TestUpdateIndexLocal(t *testing.T) {
 		Description: "v2",
 		DownloadURL: "skills/my-skill/",
 	}
-	if err := client.UpdateIndex(source, entry2, false); err != nil {
+	if err := client.UpdateIndex(ctx, source, entry2, false); err != nil {
 		t.Fatalf("UpdateIndex new version: %v", err)
 	}
 

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -1,3 +1,4 @@
+// Package runtime provides runners that execute installed skills.
 package runtime
 
 import (

--- a/internal/runtime/runner.go
+++ b/internal/runtime/runner.go
@@ -8,10 +8,12 @@ import (
 	"github.com/jayl2kor/skillhub/internal/skill"
 )
 
+// SkillRunner executes an installed skill with the given arguments.
 type SkillRunner interface {
 	Run(ctx context.Context, s skill.InstalledSkill, args []string) error
 }
 
+// RunnerFor returns the appropriate SkillRunner for the given skill type.
 func RunnerFor(skillType string) (SkillRunner, error) {
 	switch skillType {
 	case "prompt":

--- a/internal/skill/installed.go
+++ b/internal/skill/installed.go
@@ -7,12 +7,14 @@ import (
 	"time"
 )
 
+// InstalledSkill represents a skill that has been installed locally.
 type InstalledSkill struct {
 	Manifest Manifest
 	Dir      string
 	Meta     InstallMeta
 }
 
+// InstallMeta holds metadata about how and when a skill was installed.
 type InstallMeta struct {
 	InstalledAt string `json:"installed_at"`
 	Registry    string `json:"registry"`
@@ -20,6 +22,7 @@ type InstallMeta struct {
 	Checksum    string `json:"checksum,omitempty"`
 }
 
+// NewInstallMeta creates an InstallMeta with the current timestamp.
 func NewInstallMeta(registry, version, checksum string) InstallMeta {
 	return InstallMeta{
 		InstalledAt: time.Now().UTC().Format(time.RFC3339),
@@ -29,6 +32,7 @@ func NewInstallMeta(registry, version, checksum string) InstallMeta {
 	}
 }
 
+// LoadInstallMeta reads and parses install metadata from the given file path.
 func LoadInstallMeta(path string) (*InstallMeta, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -43,6 +47,7 @@ func LoadInstallMeta(path string) (*InstallMeta, error) {
 	return &meta, nil
 }
 
+// Save writes the install metadata to the given file path as JSON.
 func (m *InstallMeta) Save(path string) error {
 	data, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {

--- a/internal/skill/manifest.go
+++ b/internal/skill/manifest.go
@@ -21,6 +21,7 @@ var (
 	}
 )
 
+// Manifest describes a skill's metadata as declared in skill.json.
 type Manifest struct {
 	Name             string   `json:"name"`
 	Version          string   `json:"version"`
@@ -34,6 +35,7 @@ type Manifest struct {
 	CompatibleAgents []string `json:"compatible_agents,omitempty"`
 }
 
+// LoadManifest reads and parses a skill manifest from the given file path.
 func LoadManifest(path string) (*Manifest, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -48,6 +50,7 @@ func LoadManifest(path string) (*Manifest, error) {
 	return &m, nil
 }
 
+// Validate checks that all required manifest fields are present and well-formed.
 func (m *Manifest) Validate() error {
 	if m.Name == "" {
 		return fmt.Errorf("manifest: name is required")

--- a/internal/skill/manifest.go
+++ b/internal/skill/manifest.go
@@ -1,3 +1,4 @@
+// Package skill defines skill manifests, versioning, and installation metadata.
 package skill
 
 import (

--- a/internal/skill/version.go
+++ b/internal/skill/version.go
@@ -6,16 +6,19 @@ import (
 	"strings"
 )
 
+// SemVer represents a semantic version with major, minor, and patch components.
 type SemVer struct {
 	Major int
 	Minor int
 	Patch int
 }
 
+// String returns the semver string representation "Major.Minor.Patch".
 func (v SemVer) String() string {
 	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
 }
 
+// ParseVersion parses a "X.Y.Z" version string into a SemVer.
 func ParseVersion(s string) (SemVer, error) {
 	parts := strings.Split(s, ".")
 	if len(parts) != 3 {

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -16,7 +16,10 @@ func DetectProjectRoot() string {
 	if err == nil {
 		return strings.TrimSpace(string(out))
 	}
-	cwd, _ := os.Getwd()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
 	return cwd
 }
 

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -30,6 +30,8 @@ func (p *Paths) projectRoot() string {
 	return DetectProjectRoot()
 }
 
+// ListInstalledSkills returns all installed skills from both the global skills
+// directory and all local project agent paths, deduplicating by name.
 func ListInstalledSkills(paths *Paths) ([]skill.InstalledSkill, error) {
 	seen := make(map[string]bool)
 	var skills []skill.InstalledSkill
@@ -74,6 +76,8 @@ func ListInstalledSkills(paths *Paths) ([]skill.InstalledSkill, error) {
 	return skills, nil
 }
 
+// IsInstalled reports whether a skill with the given name is installed
+// in the global skills directory or any local project agent path.
 func IsInstalled(paths *Paths, name string) bool {
 	// Global check
 	manifestPath := filepath.Join(paths.SkillsDir, name, "skill.json")
@@ -91,6 +95,8 @@ func IsInstalled(paths *Paths, name string) bool {
 	return false
 }
 
+// GetInstalledSkill returns the installed skill with the given name,
+// checking the global directory first and then local project agent paths.
 func GetInstalledSkill(paths *Paths, name string) (*skill.InstalledSkill, error) {
 	// Check global path first
 	skillDir := filepath.Join(paths.SkillsDir, name)

--- a/internal/storage/paths.go
+++ b/internal/storage/paths.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 )
 
+// Paths holds resolved filesystem paths for skillhub's data directories.
 type Paths struct {
 	Home        string
 	Config      string
@@ -17,6 +18,7 @@ type Paths struct {
 	ProjectRoot string // project root for local skill lookup; empty means auto-detect
 }
 
+// NewPaths constructs a Paths with all directories rooted under home.
 func NewPaths(home string) *Paths {
 	return &Paths{
 		Home:      home,
@@ -28,6 +30,8 @@ func NewPaths(home string) *Paths {
 	}
 }
 
+// DefaultHome returns the skillhub home directory, using SKILLHUB_HOME if set,
+// otherwise ~/.skillhub.
 func DefaultHome() string {
 	if env := os.Getenv("SKILLHUB_HOME"); env != "" {
 		return env
@@ -41,6 +45,7 @@ func DefaultHome() string {
 	return filepath.Join(home, ".skillhub")
 }
 
+// EnsureDirectories creates all required skillhub directories if they do not exist.
 func (p *Paths) EnsureDirectories() error {
 	dirs := []string{p.Home, p.SkillsDir, p.CacheDir, p.LogDir, p.TmpDir}
 	for _, dir := range dirs {
@@ -51,6 +56,7 @@ func (p *Paths) EnsureDirectories() error {
 	return nil
 }
 
+// SkillDir returns the installation directory for the skill with the given name.
 func (p *Paths) SkillDir(name string) string {
 	return filepath.Join(p.SkillsDir, name)
 }

--- a/internal/storage/paths.go
+++ b/internal/storage/paths.go
@@ -1,3 +1,4 @@
+// Package storage manages local skill directories and path resolution.
 package storage
 
 import (

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,4 @@
+// Package version exposes the build version of skillhub.
 package version
 
 var (


### PR DESCRIPTION
## Summary

- Closes #111 — Handle unchecked errors in `os.Remove` and `tmpFile.Close`
- Closes #112 — Remove extra blank line in `update.go` (goimports style fix)
- Closes #113 — Add missing doc comments to 26 exported declarations across 6 packages
- Closes #114 — Propagate `context.Context` through `loadOrSetupConfig` and `resolveSkillDir`

## Changes

- `internal/cli/doctor.go` — log error if test file cleanup fails
- `internal/registry/client.go` — check close error after temp file write
- `internal/cli/update.go` — remove double blank line
- `internal/config/config.go` — doc comments for all exported types/funcs
- `internal/installer/install.go` — doc comments for `Installer`, `NewInstaller`, `Install`
- `internal/registry/client.go` — doc comments for `Client`, `NewClient`, `FetchIndex`, `FetchAllIndexes`, `Download`
- `internal/registry/index.go` — doc comments for `IndexEntry`, `Index`, `ParseIndex`, `Search`, `Find`, `FindVersion`, `MergeIndexes`
- `internal/runtime/runner.go` — doc comments for `SkillRunner`, `RunnerFor`
- `internal/skill/installed.go`, `manifest.go`, `version.go` — doc comments for all exported declarations
- `internal/storage/local.go`, `paths.go` — doc comments for all exported declarations
- `internal/cli/setup.go` + 9 CLI command files — `loadOrSetupConfig` now accepts `ctx context.Context`; `resolveSkillDir` now accepts `ctx context.Context`; `context.Background()` replaced with propagated command context

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)